### PR TITLE
Add custom whitespace color [WIP]

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -436,6 +436,11 @@ if v:version >= 700
 endif
 
 " }}}
+" Whitespace: {{{
+
+call s:HL('ExtraWhitespace', s:none, s:bright_red)
+
+" }}}
 " Diffs: {{{
 
 if g:srcery_transparent_background == 1 && !has('gui_running')


### PR DESCRIPTION
Hi,

Added a custom color for whitespace.  Tested with [vim-better-whitespace](https://github.com/ntpeters/vim-better-whitespace).

Did this because I thought I had `red` as the color, not `bright_red`.  Now I can't reproduce it. 😢  The backside of using a package manager that caches.

<img width="162" alt="screen shot 2018-09-11 at 21 09 26" src="https://user-images.githubusercontent.com/33870508/45382257-f79ba880-b607-11e8-92f2-af957ab978ae.png">


Did like it with orange though. 👍 
<img width="123" alt="screen shot 2018-09-11 at 21 16 11" src="https://user-images.githubusercontent.com/33870508/45382258-f8343f00-b607-11e8-9a62-6853f07cc486.png">
