### PR TITLE
Change cursor to foreground black, background yellow

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -258,7 +258,7 @@ hi! link NonText SrceryWhiteAlt
 hi! link SpecialKey SrceryWhiteAlt
 
 if g:srcery_inverse == 1
-  call s:HL('Visual', s:none, s:xgray5, s:inverse)
+  call s:HL('Visual', s:none, s:none, s:inverse)
 else
   call s:HL('Visual', s:none, s:bright_black, s:bold)
 endif

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -332,7 +332,7 @@ endif
 " Cursor: {{{
 
 " Character under cursor
-call s:HL('Cursor', s:none, s:none, s:inverse)
+call s:HL('Cursor', s:black, s:yellow)
 " Visual mode cursor, selection
 hi! link vCursor Cursor
 " Input moder cursor


### PR DESCRIPTION
Removing inverse video from cursor. Had so many problems and weird edge cases where an inverted cursor does not work. I've been forcing the cursor color to yellow in my terminal for a while now and I got to say I prefer it way. Any objections? @MindTooth 