### PR TITLE
Replace orphaned color used to highlight NonText and SpecialKey

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -283,8 +283,8 @@ if v:version >= 703
 
 endif
 
-hi! link NonText SrceryWhiteAlt
-hi! link SpecialKey SrceryWhiteAlt
+hi! link NonText SrceryXgray3
+hi! link SpecialKey SrceryXgray3
 
 if g:srcery_inverse == 1
   call s:HL('Visual', s:none, s:none, s:inverse)


### PR DESCRIPTION
These highlights used the undefined `SrceryWhiteAlt`, thus make them fallback to fg which looks distracting. After experimenting for a while, I've come to a conclusion that xgray3 would fit the best for `list` characters.