### PR TITLE
Remove explicit vim-vint version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-# vim-srcery .travis.yml
+# srcery-colors/srcery-vim/.travis.yml
 
 language: python
 
 install:
-  - pip install vim-vint==v0.3.18
+  - pip install vim-vint
 
 script:
   - vint --verbose --stat $(find . -type f -name '*.vim')


### PR DESCRIPTION
Now that the default image for building Travis CI is changed,
I feel that a test is warranted.