### PR TITLE
Add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc/tags
 TODOs.org
 *.temp
 *_archive


### PR DESCRIPTION
I installed srcery via git submodule and generated help tags with `:helptags ALL`, which creates `tags` file in `doc` directory, and git notifies that I've made differences to the repo. This fixes this problem.