### PR TITLE
doc: remove duplicate vim-sneak in plugins list, sort alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,15 +196,14 @@ Thanks to [MindTooth](https://github.com/MindTooth), Srcery now includes an [Air
 These don't require any additional configuration.
 
 * [ale](https://github.com/w0rp/ale)
+* [coc.nvim](https://github.com/neoclide/coc.nvim)
 * [ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim)
-* [vim-gitgutter](https://github.com/airblade/vim-gitgutter)
-* [vim-indent-guides](https://github.com/nathanaelkane/vim-indent-guides)
-* [vim-sneak](https://github.com/justinmk/vim-sneak)
+* [fzf.vim](https://github.com/junegunn/fzf.vim)
 * [vim-clap](https://github.com/liuchengxu/vim-clap)
+* [vim-gitgutter](https://github.com/airblade/vim-gitgutter)
+* [vim-indent-guides](https://github.com/nathanaelkane/vim-inde
 * [vim-sneak](https://github.com/justinmk/vim-sneak)
 * [vim-startify](https://github.com/mhinz/vim-startify)
-* [fzf.vim](https://github.com/junegunn/fzf.vim)
-* [coc.nvim](https://github.com/neoclide/coc.nvim)
 
 Plugin support is still a work in progress and more will come, if there is
 anything missing that you'd like to add please open an issue and let me know.


### PR DESCRIPTION
I noticed vim-sneak appeared twice in the list so I removed one.

I also sorted the list alphabetically while I'm at it :)