### PR TITLE
Italic types, TSParameter, telescope

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -199,7 +199,6 @@ call s:HL('SrceryXgray3', s:xgray3)
 call s:HL('SrceryXgray4', s:xgray4)
 call s:HL('SrceryXgray5', s:xgray5)
 call s:HL('SrceryXgray6', s:xgray6)
-
 " }}}
 " Setup Terminal Colors For Neovim: {{{
 
@@ -457,7 +456,11 @@ hi! link Number SrceryBrightMagenta
 hi! link Float SrceryBrightMagenta
 
 " Generic type
-hi! link Type SrceryBrightBlue
+if get(g:, "srcery_italic_types", 0) == 1
+  call s:HL('Type', s:bright_blue, s:none, s:italic)
+else
+  hi! link Type SrceryBrightBlue
+end
 " static, register, volatile, etc
 hi! link StorageClass SrceryOrange
 " struct, union, enum, etc.
@@ -471,6 +474,8 @@ else
   hi! link Delimiter SrceryBrightBlack
 endif
 
+" Treesitter
+call s:HL('TSParameter', s:cyan, s:none, s:italic)
 " }}}
 " Completion Menu: {{{
 
@@ -679,7 +684,13 @@ hi! link NERDTreeLinkFile SrceryBrightBlack
 hi! link NERDTreeLinkTarget SrceryBrightBlack
 
 " }}}
-
+" Telescope: "{{{
+call s:HL('TelescopeNormal', s:white, s:none)
+call s:HL('TelescopeSelection', s:green, s:none, s:bold)
+call s:HL('TelescopeMatching', s:magenta)
+call s:HL('TelescopeSelectionCaret', s:magenta)
+call s:HL('TelescopePromptPrefix', s:bright_yellow)
+" }}}
 " Filetype specific -----------------------------------------------------------
 " Diff: {{{
 

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -456,7 +456,7 @@ hi! link Number SrceryBrightMagenta
 hi! link Float SrceryBrightMagenta
 
 " Generic type
-if get(g:, "srcery_italic_types", 0) == 1
+if get(g:, 'srcery_italic_types', 0) == 1
   call s:HL('Type', s:bright_blue, s:none, s:italic)
 else
   hi! link Type SrceryBrightBlue

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -200,6 +200,7 @@ call s:HL('SrceryXgray4', s:xgray4)
 call s:HL('SrceryXgray5', s:xgray5)
 call s:HL('SrceryXgray6', s:xgray6)
 " }}}
+
 " Setup Terminal Colors For Neovim: {{{
 
 if has('nvim')
@@ -685,11 +686,13 @@ hi! link NERDTreeLinkTarget SrceryBrightBlack
 
 " }}}
 " Telescope: "{{{
+
 call s:HL('TelescopeNormal', s:white, s:none)
 call s:HL('TelescopeSelection', s:green, s:none, s:bold)
 call s:HL('TelescopeMatching', s:magenta)
 call s:HL('TelescopeSelectionCaret', s:magenta)
 call s:HL('TelescopePromptPrefix', s:bright_yellow)
+
 " }}}
 " Filetype specific -----------------------------------------------------------
 " Diff: {{{


### PR DESCRIPTION
Italic types (toggled by `g:srcery_italic_types`)-
before:
![Grimshot 2020-12-13 22-58-29](https://user-images.githubusercontent.com/36493671/102019023-ddc50f00-3d96-11eb-8aca-480dd12cc848.png)
after:
![Grimshot 2020-12-13 22-58-02](https://user-images.githubusercontent.com/36493671/102019026-e3225980-3d96-11eb-887d-ef51cca4d3a2.png)
