### PR TITLE
feat: add guisp fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ default: 0
 
 #### g:srcery_guisp_fallback
 
-
 Sets up alternate highlighting for colored underline/undercurl. Some
 environments are unable to color underline, so this setting will set either the
 background or foreground to whatever color the underline is supposed to be.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ Dims lisp dialects delimiters to a fairly dark gray (xgray5 specifically)
 
 default: 0
 
+#### g:srcery_guisp_fallback
+
+
+Sets up alternate highlighting for colored underline/undercurl. Some
+environments are unable to color underline, so this setting will set either the
+background or foreground to whatever color the underline is supposed to be.
+
+This comes in handy if colored underline doesn't work, or underline is disabled entirely.
+
+default: 'NONE'
+
+possible Values: 'fg', 'bg'
+
 ## Usage
 ```
 :color srcery

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -95,6 +95,10 @@ if !exists('g:srcery_dim_lisp_paren')
   let g:srcery_dim_lisp_paren=0
 endif
 
+if !exists('g:srcery_guisp_fallback') || index(['fg', 'bg'], g:srcery_guisp_fallback) == -1
+  let g:srcery_guisp_fallback='NONE'
+endif
+
 " }}}
 " Setup Emphasis: {{{
 
@@ -144,6 +148,18 @@ function! s:HL(group, fg, ...)
     let l:emstr = a:2
   else
     let l:emstr = 'NONE,'
+  endif
+
+  " special fallback
+  if a:0 >= 3
+    if g:srcery_guisp_fallback != 'NONE'
+      let fg = a:3
+    endif
+
+    " bg fallback mode should invert higlighting
+    if g:srcery_guisp_fallback == 'bg'
+      let emstr .= 'inverse,'
+    endif
   endif
 
   let l:histring = [ 'hi', a:group,

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -152,12 +152,12 @@ function! s:HL(group, fg, ...)
 
   " special fallback
   if a:0 >= 3
-    if g:srcery_guisp_fallback != 'NONE'
+    if g:srcery_guisp_fallback !=# 'NONE'
       let fg = a:3
     endif
 
     " bg fallback mode should invert higlighting
-    if g:srcery_guisp_fallback == 'bg'
+    if g:srcery_guisp_fallback ==# 'bg'
       let emstr .= 'inverse,'
     endif
   endif


### PR DESCRIPTION
This pull request introduce a new variable `g:srcery_guisp_fallback` that can enable highlighting on words that is supposed to have a colored underline/undercurl in environments that have underline/undercurl disabled or not working (terminal vim)

This pull request fixes issue #61 
