### PR TITLE
v1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2018 for portions of Srcery are held by morhetz <morhetz@gmail.com> as part of Gruvbox.
-All other Copyright (c) 2018 for Srcery are held by Daniel Berg <mail@roosta.sh> and contributers of Srcery.
+All other Copyright (c) 2021 for Srcery are held by Daniel Berg <mail@roosta.sh> and contributers of Srcery.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ terminal configurations in the
 | blue          | 4  | `g:srcery_blue`           | #2C78BF | 44, 120, 191  | ![blue](https://place-hold.it/100x24/2C78BF?text=+)           |
 | magenta       | 5  | `g:srcery_magenta`        | #E02C6D | 224, 44,  109 | ![magenta](https://place-hold.it/100x24/E02C6D?text=+)        |
 | cyan          | 6  | `g:srcery_cyan`           | #0AAEB3 | 10, 174, 179  | ![cyan](https://place-hold.it/100x24/0AAEB3?text=+)           |
-| white         | 7  | `g:srcery_white`          | #D0BFA1 | 208, 191, 161 | ![white](https://place-hold.it/100x24/D0BFA1?text=+)          |
+| white         | 7  | `g:srcery_white`          | #BAA67F | 186, 166, 127 | ![white](https://place-hold.it/100x24/BAA67F?text=+)          |
 | brightblack   | 8  | `g:srcery_bright_black`   | #918175 | 145, 129, 117 | ![bright_black](https://place-hold.it/100x24/918175?text=+)   |
 | brightred     | 9  | `g:srcery_bright_red`     | #F75341 | 247, 83, 65   | ![bright_red](https://place-hold.it/100x24/F75341?text=+)     |
 | brightgreen   | 10 | `g:srcery_bright_green`   | #98BC37 | 152, 188, 55  | ![bright_green](https://place-hold.it/100x24/98BC37?text=+)   |

--- a/README.md
+++ b/README.md
@@ -104,10 +104,17 @@ default: 1
 Enables italic text.
 default: gui 1, term 0
 
-#### g:srcery_transparent_background
+#### g:srcery_bg_passthrough
 
-Removes the background color in terminal.
-This is a bit of an experimental option, and it cause issues in certain terminals.
+Lets the terminal control the background color in Vim, setting the background
+in vim to NONE.
+
+A possible use case for this could be you want to manipulate the background
+color in the terminal, and let the results bubble up to Vim, like [this](https://github.com/roosta/tmux-pop).
+
+This is a bit of an experimental option, and can cause issues in certain
+terminals.
+
 default: 0
 
 #### g:srcery_underline

--- a/README.md
+++ b/README.md
@@ -15,40 +15,40 @@ so-called “ASCII” colors to the ones in the table below. There's a list of
 terminal configurations in the
 [srcery-terminal](https://github.com/srcery-colors/srcery-terminal) repository.
 
-| TERMCOL        | NR | HEX     | RGB           | IMG                                                          |
-|----------------|----|---------|---------------|--------------------------------------------------------------|
-| black          | 0  | #1C1B19 | 28,  27,  25  | ![black](https://place-hold.it/100x24/1C1B19?text=+)          |
-| red            | 1  | #EF2F27 | 239, 47, 39   | ![red](https://place-hold.it/100x24/EF2F27?text=+)            |
-| green          | 2  | #519F50 | 81,  159, 80  | ![green](https://place-hold.it/100x24/519F50?text=+)          |
-| yellow         | 3  | #FBB829 | 251, 184, 41  | ![yellow](https://place-hold.it/100x24/FBB829?text=+)         |
-| blue           | 4  | #2C78BF | 44, 120, 191  | ![blue](https://place-hold.it/100x24/2C78BF?text=+)           |
-| magenta        | 5  | #E02C6D | 224, 44,  109 | ![magenta](https://place-hold.it/100x24/E02C6D?text=+)        |
-| cyan           | 6  | #0AAEB3 | 10, 174, 179  | ![cyan](https://place-hold.it/100x24/0AAEB3?text=+)           |
-| white          | 7  | #D0BFA1 | 208, 191, 161 | ![white](https://place-hold.it/100x24/D0BFA1?text=+)          |
-| brightblack    | 8  | #918175 | 145, 129, 117 | ![bright_black](https://place-hold.it/100x24/918175?text=+)   |
-| brightred      | 9  | #F75341 | 247, 83, 65   | ![bright_red](https://place-hold.it/100x24/F75341?text=+)     |
-| brightgreen    | 10 | #98BC37 | 152, 188, 55  | ![bright_green](https://place-hold.it/100x24/98BC37?text=+)   |
-| brightyellow   | 11 | #FED06E | 254, 208, 110 | ![bright_yellow](https://place-hold.it/100x24/FED06E?text=+)  |
-| brightblue     | 12 | #68A8E4 | 104, 168, 228 | ![bright_blue](https://place-hold.it/100x24/68A8E4?text=+)    |
-| brightmagenta  | 13 | #FF5C8F | 255, 92, 143  | ![bright_magenta](https://place-hold.it/100x24/FF5C8F?text=+) |
-| brightcyan     | 14 | #53FDE9 | 83, 253, 233  | ![bright_cyan](https://place-hold.it/100x24/53FDE9?text=+)    |
-| brightwhite    | 15 | #FCE8C3 | 252, 232, 195 | ![bright_white](https://place-hold.it/100x24/FCE8C3?text=+)   |
+| TERMCOL       | NR | VAR                     | HEX     | RGB           | IMG                                                           |
+|---------------|----|-------------------------|---------|---------------|---------------------------------------------------------------|
+| black         | 0  | `g:srcery_black`          | #1C1B19 | 28,  27,  25  | ![black](https://place-hold.it/100x24/1C1B19?text=+)          |
+| red           | 1  | `g:srcery_red`            | #EF2F27 | 239, 47, 39   | ![red](https://place-hold.it/100x24/EF2F27?text=+)            |
+| green         | 2  | `g:srcery_green`          | #519F50 | 81,  159, 80  | ![green](https://place-hold.it/100x24/519F50?text=+)          |
+| yellow        | 3  | `g:srcery_yellow`         | #FBB829 | 251, 184, 41  | ![yellow](https://place-hold.it/100x24/FBB829?text=+)         |
+| blue          | 4  | `g:srcery_blue`           | #2C78BF | 44, 120, 191  | ![blue](https://place-hold.it/100x24/2C78BF?text=+)           |
+| magenta       | 5  | `g:srcery_magenta`        | #E02C6D | 224, 44,  109 | ![magenta](https://place-hold.it/100x24/E02C6D?text=+)        |
+| cyan          | 6  | `g:srcery_cyan`           | #0AAEB3 | 10, 174, 179  | ![cyan](https://place-hold.it/100x24/0AAEB3?text=+)           |
+| white         | 7  | `g:srcery_white`          | #D0BFA1 | 208, 191, 161 | ![white](https://place-hold.it/100x24/D0BFA1?text=+)          |
+| brightblack   | 8  | `g:srcery_bright_black`   | #918175 | 145, 129, 117 | ![bright_black](https://place-hold.it/100x24/918175?text=+)   |
+| brightred     | 9  | `g:srcery_bright_red`     | #F75341 | 247, 83, 65   | ![bright_red](https://place-hold.it/100x24/F75341?text=+)     |
+| brightgreen   | 10 | `g:srcery_bright_green`   | #98BC37 | 152, 188, 55  | ![bright_green](https://place-hold.it/100x24/98BC37?text=+)   |
+| brightyellow  | 11 | `g:srcery_bright_yellow`  | #FED06E | 254, 208, 110 | ![bright_yellow](https://place-hold.it/100x24/FED06E?text=+)  |
+| brightblue    | 12 | `g:srcery_bright_blue`    | #68A8E4 | 104, 168, 228 | ![bright_blue](https://place-hold.it/100x24/68A8E4?text=+)    |
+| brightmagenta | 13 | `g:srcery_bright_magenta` | #FF5C8F | 255, 92, 143  | ![bright_magenta](https://place-hold.it/100x24/FF5C8F?text=+) |
+| brightcyan    | 14 | `g:srcery_bright_cyan`    | #53FDE9 | 83, 253, 233  | ![bright_cyan](https://place-hold.it/100x24/53FDE9?text=+)    |
+| brightwhite   | 15 | `g:srcery_bright_white`   | #FCE8C3 | 252, 232, 195 | ![bright_white](https://place-hold.it/100x24/FCE8C3?text=+)   |
 
 Additionally Srcery uses some [xterm 256
 colors](https://en.wikipedia.org/wiki/Xterm#/media/File:Xterm_256color_chart.svg)
 to pad out the color selection, no extra configuration needed.
 
-| NAME          | NR  | HEX     | RGB         | IMG                                                         |
-|---------------|-----|---------|-------------|-------------------------------------------------------------|
-| orange        | 202 | #FF5F00 | 255, 95, 0  | ![orange](https://place-hold.it/100x24/FF5F00?text=+)        |
-| bright_orange | 208 | #FF8700 | 255, 135, 0 | ![bright_orange](https://place-hold.it/100x24/FF8700?text=+) |
-| hard_black    | 233 | #121212 | 18, 18, 18  | ![hard_black](https://place-hold.it/100x24/121212?text=+)    |
-| xgray1        | 235 | #262626 | 38, 38, 38  | ![xgray1](https://place-hold.it/100x24/262626?text=+)        |
-| xgray2        | 236 | #303030 | 48, 48, 48  | ![xgray2](https://place-hold.it/100x24/303030?text=+)        |
-| xgray3        | 237 | #3A3A3A | 58, 58, 58  | ![xgray3](https://place-hold.it/100x24/3A3A3A?text=+)        |
-| xgray4        | 238 | #444444 | 68, 68, 68  | ![xgray4](https://place-hold.it/100x24/444444?text=+)        |
-| xgray5        | 239 | #4E4E4E | 78, 78, 78  | ![xgray5](https://place-hold.it/100x24/4E4E4E?text=+)        |
-| xgray6        | 240 | #585858 | 88, 88, 88  | ![xgray6](https://place-hold.it/100x24/585858?text=+)        |
+| NAME          | NR  | VAR                    | HEX     | RGB         | IMG                                                          |
+|---------------|-----|------------------------|---------|-------------|--------------------------------------------------------------|
+| orange        | 202 | `g:srcery_orange`        | #FF5F00 | 255, 95, 0  | ![orange](https://place-hold.it/100x24/FF5F00?text=+)        |
+| bright_orange | 208 | `g:srcery_bright_orange` | #FF8700 | 255, 135, 0 | ![bright_orange](https://place-hold.it/100x24/FF8700?text=+) |
+| hard_black    | 233 | `g:srcery_hard_black`    | #121212 | 18, 18, 18  | ![hard_black](https://place-hold.it/100x24/121212?text=+)    |
+| xgray1        | 235 | `g:srcery_xgray`         | #262626 | 38, 38, 38  | ![xgray1](https://place-hold.it/100x24/262626?text=+)        |
+| xgray2        | 236 | `g:srcery_xgray`         | #303030 | 48, 48, 48  | ![xgray2](https://place-hold.it/100x24/303030?text=+)        |
+| xgray3        | 237 | `g:srcery_xgray`         | #3A3A3A | 58, 58, 58  | ![xgray3](https://place-hold.it/100x24/3A3A3A?text=+)        |
+| xgray4        | 238 | `g:srcery_xgray`         | #444444 | 68, 68, 68  | ![xgray4](https://place-hold.it/100x24/444444?text=+)        |
+| xgray5        | 239 | `g:srcery_xgray`         | #4E4E4E | 78, 78, 78  | ![xgray5](https://place-hold.it/100x24/4E4E4E?text=+)        |
+| xgray6        | 240 | `g:srcery_xgray`         | #585858 | 88, 88, 88  | ![xgray6](https://place-hold.it/100x24/585858?text=+)        |
 
 ## Installation
 
@@ -88,11 +88,25 @@ Plug 'srcery-colors/srcery-vim'
 Srcery includes a few toggles due to discrepancies in the various setups possible.
 To change any of these you'd put something like this in your `.vimrc`
 
-```viml
+```vim
 let g:srcery_italic = 1
 ```
 
 Make sure that you set these variables before assigning `colorscheme`.
+
+#### Colors
+
+You can customize each of Srcery's colors, to customize say the red color:
+```vim
+let g:srcery_red = '#FF0000'
+```
+
+Refer to the [table](#TUI) for a full list of color variables, hexes and more.
+
+This will only work on `set termguicolors` and in Gvim, to override terminal
+colors, do so in your [terminal
+configuration](https://github.com/srcery-colors/srcery-terminal).
+
 
 #### g:srcery_bold
 

--- a/autoload/lightline/colorscheme/srcery.vim
+++ b/autoload/lightline/colorscheme/srcery.vim
@@ -3,7 +3,6 @@
 " Description: Srcery colorscheme for Lightline (itchyny/lightline.vim)
 " Author: Roosta <mail@roosta>
 " Source: https://github.com/morhetz/gruvbox/blob/master/autoload/lightline/colorscheme/gruvbox.vim
-" Last Modified: 2017-03-28
 " -----------------------------------------------------------------------------
 
 if exists('g:lightline')

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -20,40 +20,111 @@ if !has('gui_running') && &t_Co != 256
   finish
 endif
 
-" Palette {{{
+" Setup Variables: {{{1
+" Colors {{{2
 
-let s:black          = ['#1C1B19', 0]
-let s:red            = ['#EF2F27', 1]
-let s:green          = ['#519F50', 2]
-let s:yellow         = ['#FBB829', 3]
-let s:blue           = ['#2C78BF', 4]
-let s:magenta        = ['#E02C6D', 5]
-let s:cyan           = ['#0AAEB3', 6]
-let s:white          = ['#D0BFA1', 7]
-let s:bright_black   = ['#918175', 8]
-let s:bright_red     = ['#F75341', 9]
-let s:bright_green   = ['#98BC37', 10]
-let s:bright_yellow  = ['#FED06E', 11]
-let s:bright_blue    = ['#68A8E4', 12]
-let s:bright_magenta = ['#FF5C8F', 13]
-let s:bright_cyan    = ['#53FDE9', 14]
-let s:bright_white   = ['#FCE8C3', 15]
+if !exists('g:srcery_black')
+  let g:srcery_black='#1C1B19'
+endif
 
-" xterm colors.
-let s:orange        = ['#FF5F00', 202]
-let s:bright_orange = ['#FF8700', 208]
-let s:hard_black    = ['#121212', 233]
-let s:xgray1        = ['#262626', 235]
-let s:xgray2        = ['#303030', 236]
-let s:xgray3        = ['#3A3A3A', 237]
-let s:xgray4        = ['#444444', 238]
-let s:xgray5        = ['#4E4E4E', 239]
-let s:xgray6        = ['#585858', 240]
+if !exists('g:srcery_red')
+  let g:srcery_red='#EF2F27'
+endif
 
-"}}}
-" Setup Variables: {{{
+if !exists('g:srcery_green')
+  let g:srcery_green='#519F50'
+endif
 
-let s:none = ['NONE', 'NONE']
+if !exists('g:srcery_yellow')
+  let g:srcery_yellow='#FBB829'
+endif
+
+if !exists('g:srcery_blue')
+  let g:srcery_blue='#2C78BF'
+endif
+
+if !exists('g:srcery_magenta')
+  let g:srcery_magenta='#E02C6D'
+endif
+
+if !exists('g:srcery_cyan')
+  let g:srcery_cyan='#0AAEB3'
+endif
+
+if !exists('g:srcery_white')
+  let g:srcery_white='#D0BFA1'
+endif
+
+if !exists('g:srcery_bright_black')
+  let g:srcery_bright_black='#918175'
+endif
+
+if !exists('g:srcery_bright_red')
+  let g:srcery_bright_red='#F75341'
+endif
+
+if !exists('g:srcery_bright_green')
+  let g:srcery_bright_green='#98BC37'
+endif
+
+if !exists('g:srcery_bright_yellow')
+  let g:srcery_bright_yellow='#FED06E'
+endif
+
+if !exists('g:srcery_bright_blue')
+  let g:srcery_bright_blue='#68A8E4'
+endif
+
+if !exists('g:srcery_bright_magenta')
+  let g:srcery_bright_magenta='#FF5C8F'
+endif
+
+if !exists('g:srcery_bright_cyan')
+  let g:srcery_bright_cyan='#53FDE9'
+endif
+
+if !exists('g:srcery_bright_white')
+  let g:srcery_bright_white='#FCE8C3'
+endif
+
+if !exists('g:srcery_orange')
+  let g:srcery_orange='#FF5F00'
+endif
+
+if !exists('g:srcery_bright_orange')
+  let g:srcery_bright_orange='#FF8700'
+endif
+
+if !exists('g:srcery_hard_black')
+  let g:srcery_hard_black='#121212'
+endif
+
+if !exists('g:srcery_xgray1')
+  let g:srcery_xgray1='#262626'
+endif
+
+if !exists('g:srcery_xgray2')
+  let g:srcery_xgray2='#303030'
+endif
+
+if !exists('g:srcery_xgray3')
+  let g:srcery_xgray3='#3A3A3A'
+endif
+
+if !exists('g:srcery_xgray4')
+  let g:srcery_xgray4='#444444'
+endif
+
+if !exists('g:srcery_xgray5')
+  let g:srcery_xgray5='#4E4E4E'
+endif
+
+if !exists('g:srcery_xgray6')
+  let g:srcery_xgray6='#585858'
+endif
+
+" }}}
+" Options {{{2
 
 if !exists('g:srcery_bold')
   let g:srcery_bold=1
@@ -100,6 +171,41 @@ if !exists('g:srcery_guisp_fallback') || index(['fg', 'bg'], g:srcery_guisp_fall
 endif
 
 " }}}
+" }}}
+" Palette {{{
+
+let s:none           = ['NONE', 'NONE']
+
+" 16 base colors
+let s:black          = [g:srcery_black, 0]
+let s:red            = [g:srcery_red, 1]
+let s:green          = [g:srcery_green, 2]
+let s:yellow         = [g:srcery_yellow, 3]
+let s:blue           = [g:srcery_blue, 4]
+let s:magenta        = [g:srcery_magenta, 5]
+let s:cyan           = [g:srcery_cyan, 6]
+let s:white          = [g:srcery_white, 7]
+let s:bright_black   = [g:srcery_bright_black, 8]
+let s:bright_red     = [g:srcery_bright_red, 9]
+let s:bright_green   = [g:srcery_bright_green, 10]
+let s:bright_yellow  = [g:srcery_bright_yellow, 11]
+let s:bright_blue    = [g:srcery_bright_blue, 12]
+let s:bright_magenta = [g:srcery_bright_magenta, 13]
+let s:bright_cyan    = [g:srcery_bright_cyan, 14]
+let s:bright_white   = [g:srcery_bright_white, 15]
+
+" xterm colors.
+let s:orange         = [g:srcery_orange, 202]
+let s:bright_orange  = [g:srcery_bright_orange, 208]
+let s:hard_black     = [g:srcery_hard_black, 233]
+let s:xgray1         = [g:srcery_xgray1, 235]
+let s:xgray2         = [g:srcery_xgray2, 236]
+let s:xgray3         = [g:srcery_xgray3, 237]
+let s:xgray4         = [g:srcery_xgray4, 238]
+let s:xgray5         = [g:srcery_xgray5, 239]
+let s:xgray6         = [g:srcery_xgray6, 240]
+
+"}}}
 " Setup Emphasis: {{{
 
 let s:bold = 'bold,'

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -52,7 +52,7 @@ if !exists('g:srcery_cyan')
 endif
 
 if !exists('g:srcery_white')
-  let g:srcery_white='#D0BFA1'
+  let g:srcery_white='#BAA67F'
 endif
 
 if !exists('g:srcery_bright_black')

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -820,8 +820,8 @@ if g:srcery_dim_lisp_paren == 1
   hi! link schemeParentheses SrceryXgray6
   hi! link clojureParen SrceryXgray6
 else
-  hi! link schemeParentheses SrceryBrightBlack
-  hi! link clojureParen SrceryBrightBlack
+  hi! link schemeParentheses SrceryWhite
+  hi! link clojureParen SrceryWhite
 endif
 
 hi! link clojureKeyword SrceryBlue

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -67,8 +67,8 @@ if !exists('g:srcery_italic')
   endif
 endif
 
-if !exists('g:srcery_transparent_background')
-  let g:srcery_transparent_background=0
+if !exists('g:srcery_bg_passthrough')
+  let g:srcery_bg_passthrough=0
 endif
 
 if !exists('g:srcery_undercurl')
@@ -284,7 +284,7 @@ endif
 
 " Normal text
 "
-if g:srcery_transparent_background == 1 && !has('gui_running')
+if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('Normal', s:bright_white, s:none)
  else
   call s:HL('Normal', s:bright_white, s:black)
@@ -319,7 +319,7 @@ if v:version >= 703
   call s:HL('Conceal', s:blue, s:none)
 
   " Line number of CursorLine
-  if g:srcery_transparent_background == 1 && !has('gui_running')
+  if g:srcery_bg_passthrough == 1 && !has('gui_running')
     call s:HL('CursorLineNr', s:yellow, s:none)
   else
     call s:HL('CursorLineNr', s:yellow, s:black)
@@ -350,7 +350,7 @@ call s:HL('Underlined', s:blue, s:none, s:underline)
 
 call s:HL('StatusLine',   s:bright_white, s:xgray2)
 
-if g:srcery_transparent_background == 1 && !has('gui_running')
+if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('StatusLineNC', s:bright_black, s:none, s:underline)
 
   " The column separating vertically split windows
@@ -387,7 +387,7 @@ hi! link WarningMsg SrceryRedBold
 " Line number for :number and :# commands
 call s:HL('LineNr', s:bright_black)
 
-if g:srcery_transparent_background == 1 && !has('gui_running')
+if g:srcery_bg_passthrough == 1 && !has('gui_running')
   " Column where signs are displayed
   " TODO Possibly need to fix  SignColumn
   call s:HL('SignColumn', s:none, s:none)
@@ -420,7 +420,7 @@ hi! link Special SrceryOrange
 
 call s:HL('Comment', s:bright_black, s:none, s:italic)
 
-if g:srcery_transparent_background == 1 && !has('gui_running')
+if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('Todo', s:bright_white, s:none, s:bold . s:italic)
 else
   call s:HL('Todo', s:bright_white, s:black, s:bold . s:italic)
@@ -504,7 +504,7 @@ if v:version >= 700
   " Popup menu: selected item
   call s:HL('PmenuSel', s:bright_white, s:blue, s:bold)
 
-  if g:srcery_transparent_background == 1 && !has('gui_running')
+  if g:srcery_bg_passthrough == 1 && !has('gui_running')
     " Popup menu: scrollbar
     call s:HL('PmenuSbar', s:none, s:none)
     " Popup menu: scrollbar thumb
@@ -518,7 +518,7 @@ endif
 " }}}
 " Diffs: {{{
 
-if g:srcery_transparent_background == 1 && !has('gui_running')
+if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('DiffDelete', s:red, s:none)
   call s:HL('DiffAdd',    s:green, s:none)
   call s:HL('DiffChange', s:cyan, s:none)
@@ -757,7 +757,7 @@ call s:HL('htmlLink', s:bright_white, s:none, s:underline)
 
 hi! link htmlSpecialChar SrceryYellow
 
-if g:srcery_transparent_background == 1 && !has('gui_running')
+if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('htmlBold', s:bright_white, s:none, s:bold)
   call s:HL('htmlBoldUnderline', s:bright_white, s:none, s:bold . s:underline)
   call s:HL('htmlBoldItalic', s:bright_white, s:none, s:bold . s:italic)


### PR DESCRIPTION
A few things I felt was needed for v1,

- Make colors customizable, e.g. `let g:srcery_red = '#FF0000'`
- Rename `g:srcery_transparent_background` -> `g:srcery_bg_passthrough`. Update readme and add better explanation (hopefully)
- Update white color, makes it slightly darker, and has a bit more yellow. The issue I had with the previous one is that it doesn't stand out, and looks very much like white. This gives it a bit more identity, hopefully making it more useful in the future:
  - Old white: 
    ![image](https://user-images.githubusercontent.com/4509009/119235523-390fe000-bb33-11eb-9b26-2bbc79bf22ef.png)

  - New white:
    ![image](https://user-images.githubusercontent.com/4509009/119235536-49c05600-bb33-11eb-814d-74b7c93f8840.png)

edit: bleh, not obvious what the colors are in those images, from the top its `bright_white`, `white`, and `bright_black`. I thought comparing those colors made my point clearer