### PR TITLE
Markdown and javascript revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,40 +17,40 @@ so-called “ASCII” colors to the ones in the table below. There's a list of
 terminal configurations in the
 [srcery-terminal](https://github.com/srcery-colors/srcery-terminal) repository.
 
-| TERMCOL       | NR | VAR                     | HEX     | RGB           | IMG                                                           |
-|---------------|----|-------------------------|---------|---------------|---------------------------------------------------------------|
-| black         | 0  | `g:srcery_black`          | #1C1B19 | 28,  27,  25  | ![black](https://place-hold.it/100x24/1C1B19?text=+)          |
-| red           | 1  | `g:srcery_red`            | #EF2F27 | 239, 47, 39   | ![red](https://place-hold.it/100x24/EF2F27?text=+)            |
-| green         | 2  | `g:srcery_green`          | #519F50 | 81,  159, 80  | ![green](https://place-hold.it/100x24/519F50?text=+)          |
-| yellow        | 3  | `g:srcery_yellow`         | #FBB829 | 251, 184, 41  | ![yellow](https://place-hold.it/100x24/FBB829?text=+)         |
-| blue          | 4  | `g:srcery_blue`           | #2C78BF | 44, 120, 191  | ![blue](https://place-hold.it/100x24/2C78BF?text=+)           |
-| magenta       | 5  | `g:srcery_magenta`        | #E02C6D | 224, 44,  109 | ![magenta](https://place-hold.it/100x24/E02C6D?text=+)        |
-| cyan          | 6  | `g:srcery_cyan`           | #0AAEB3 | 10, 174, 179  | ![cyan](https://place-hold.it/100x24/0AAEB3?text=+)           |
-| white         | 7  | `g:srcery_white`          | #BAA67F | 186, 166, 127 | ![white](https://place-hold.it/100x24/BAA67F?text=+)          |
-| brightblack   | 8  | `g:srcery_bright_black`   | #918175 | 145, 129, 117 | ![bright_black](https://place-hold.it/100x24/918175?text=+)   |
-| brightred     | 9  | `g:srcery_bright_red`     | #F75341 | 247, 83, 65   | ![bright_red](https://place-hold.it/100x24/F75341?text=+)     |
-| brightgreen   | 10 | `g:srcery_bright_green`   | #98BC37 | 152, 188, 55  | ![bright_green](https://place-hold.it/100x24/98BC37?text=+)   |
-| brightyellow  | 11 | `g:srcery_bright_yellow`  | #FED06E | 254, 208, 110 | ![bright_yellow](https://place-hold.it/100x24/FED06E?text=+)  |
-| brightblue    | 12 | `g:srcery_bright_blue`    | #68A8E4 | 104, 168, 228 | ![bright_blue](https://place-hold.it/100x24/68A8E4?text=+)    |
-| brightmagenta | 13 | `g:srcery_bright_magenta` | #FF5C8F | 255, 92, 143  | ![bright_magenta](https://place-hold.it/100x24/FF5C8F?text=+) |
-| brightcyan    | 14 | `g:srcery_bright_cyan`    | #2BE4D0 | 43, 228, 208  | ![bright_cyan](https://place-hold.it/100x24/2BE4D0?text=+)    |
-| brightwhite   | 15 | `g:srcery_bright_white`   | #FCE8C3 | 252, 232, 195 | ![bright_white](https://place-hold.it/100x24/FCE8C3?text=+)   |
+| TERMCOL       | NR | VAR                       | HEX     | RGB           | IMG                                                            |
+|---------------|----|---------------------------|---------|---------------|----------------------------------------------------------------|
+| black         | 0  | `g:srcery_black`          | #1C1B19 | 28,  27,  25  | ![black](https://place-hold.it/100x24/1C1B19?text=+)           |
+| red           | 1  | `g:srcery_red`            | #EF2F27 | 239, 47, 39   | ![red](https://place-hold.it/100x24/EF2F27?text=+)             |
+| green         | 2  | `g:srcery_green`          | #519F50 | 81,  159, 80  | ![green](https://place-hold.it/100x24/519F50?text=+)           |
+| yellow        | 3  | `g:srcery_yellow`         | #FBB829 | 251, 184, 41  | ![yellow](https://place-hold.it/100x24/FBB829?text=+)          |
+| blue          | 4  | `g:srcery_blue`           | #2C78BF | 44, 120, 191  | ![blue](https://place-hold.it/100x24/2C78BF?text=+)            |
+| magenta       | 5  | `g:srcery_magenta`        | #E02C6D | 224, 44,  109 | ![magenta](https://place-hold.it/100x24/E02C6D?text=+)         |
+| cyan          | 6  | `g:srcery_cyan`           | #0AAEB3 | 10, 174, 179  | ![cyan](https://place-hold.it/100x24/0AAEB3?text=+)            |
+| white         | 7  | `g:srcery_white`          | #BAA67F | 186, 166, 127 | ![white](https://place-hold.it/100x24/BAA67F?text=+)           |
+| brightblack   | 8  | `g:srcery_bright_black`   | #918175 | 145, 129, 117 | ![bright\_black](https://place-hold.it/100x24/918175?text=+)   |
+| brightred     | 9  | `g:srcery_bright_red`     | #F75341 | 247, 83, 65   | ![bright\_red](https://place-hold.it/100x24/F75341?text=+)     |
+| brightgreen   | 10 | `g:srcery_bright_green`   | #98BC37 | 152, 188, 55  | ![bright\_green](https://place-hold.it/100x24/98BC37?text=+)   |
+| brightyellow  | 11 | `g:srcery_bright_yellow`  | #FED06E | 254, 208, 110 | ![bright\_yellow](https://place-hold.it/100x24/FED06E?text=+)  |
+| brightblue    | 12 | `g:srcery_bright_blue`    | #68A8E4 | 104, 168, 228 | ![bright\_blue](https://place-hold.it/100x24/68A8E4?text=+)    |
+| brightmagenta | 13 | `g:srcery_bright_magenta` | #FF5C8F | 255, 92, 143  | ![bright\_magenta](https://place-hold.it/100x24/FF5C8F?text=+) |
+| brightcyan    | 14 | `g:srcery_bright_cyan`    | #2BE4D0 | 43, 228, 208  | ![bright\_cyan](https://place-hold.it/100x24/2BE4D0?text=+)    |
+| brightwhite   | 15 | `g:srcery_bright_white`   | #FCE8C3 | 252, 232, 195 | ![bright\_white](https://place-hold.it/100x24/FCE8C3?text=+)   |
 
 Additionally Srcery uses some [xterm 256
 colors](https://en.wikipedia.org/wiki/Xterm#/media/File:Xterm_256color_chart.svg)
 to pad out the color selection, no extra configuration needed.
 
-| NAME          | NR  | VAR                    | HEX     | RGB         | IMG                                                          |
-|---------------|-----|------------------------|---------|-------------|--------------------------------------------------------------|
-| orange        | 202 | `g:srcery_orange`        | #FF5F00 | 255, 95, 0  | ![orange](https://place-hold.it/100x24/FF5F00?text=+)        |
-| bright_orange | 208 | `g:srcery_bright_orange` | #FF8700 | 255, 135, 0 | ![bright_orange](https://place-hold.it/100x24/FF8700?text=+) |
-| hard_black    | 233 | `g:srcery_hard_black`    | #121212 | 18, 18, 18  | ![hard_black](https://place-hold.it/100x24/121212?text=+)    |
-| xgray1        | 235 | `g:srcery_xgray1`         | #262626 | 38, 38, 38  | ![xgray1](https://place-hold.it/100x24/262626?text=+)        |
-| xgray2        | 236 | `g:srcery_xgray2`         | #303030 | 48, 48, 48  | ![xgray2](https://place-hold.it/100x24/303030?text=+)        |
-| xgray3        | 237 | `g:srcery_xgray3`         | #3A3A3A | 58, 58, 58  | ![xgray3](https://place-hold.it/100x24/3A3A3A?text=+)        |
-| xgray4        | 238 | `g:srcery_xgray4`         | #444444 | 68, 68, 68  | ![xgray4](https://place-hold.it/100x24/444444?text=+)        |
-| xgray5        | 239 | `g:srcery_xgray5`         | #4E4E4E | 78, 78, 78  | ![xgray5](https://place-hold.it/100x24/4E4E4E?text=+)        |
-| xgray6        | 240 | `g:srcery_xgray6`         | #585858 | 88, 88, 88  | ![xgray6](https://place-hold.it/100x24/585858?text=+)        |
+| NAME           | NR  | VAR                      | HEX     | RGB         | IMG                                                           |
+|----------------|-----|--------------------------|---------|-------------|---------------------------------------------------------------|
+| orange         | 202 | `g:srcery_orange`        | #FF5F00 | 255, 95, 0  | ![orange](https://place-hold.it/100x24/FF5F00?text=+)         |
+| bright\_orange | 208 | `g:srcery_bright_orange` | #FF8700 | 255, 135, 0 | ![bright\_orange](https://place-hold.it/100x24/FF8700?text=+) |
+| hard\_black    | 233 | `g:srcery_hard_black`    | #121212 | 18, 18, 18  | ![hard\_black](https://place-hold.it/100x24/121212?text=+)    |
+| xgray1         | 235 | `g:srcery_xgray1`        | #262626 | 38, 38, 38  | ![xgray1](https://place-hold.it/100x24/262626?text=+)         |
+| xgray2         | 236 | `g:srcery_xgray2`        | #303030 | 48, 48, 48  | ![xgray2](https://place-hold.it/100x24/303030?text=+)         |
+| xgray3         | 237 | `g:srcery_xgray3`        | #3A3A3A | 58, 58, 58  | ![xgray3](https://place-hold.it/100x24/3A3A3A?text=+)         |
+| xgray4         | 238 | `g:srcery_xgray4`        | #444444 | 68, 68, 68  | ![xgray4](https://place-hold.it/100x24/444444?text=+)         |
+| xgray5         | 239 | `g:srcery_xgray5`        | #4E4E4E | 78, 78, 78  | ![xgray5](https://place-hold.it/100x24/4E4E4E?text=+)         |
+| xgray6         | 240 | `g:srcery_xgray6`        | #585858 | 88, 88, 88  | ![xgray6](https://place-hold.it/100x24/585858?text=+)         |
 
 ## Installation
 
@@ -128,31 +128,31 @@ configuration](https://github.com/srcery-colors/srcery-terminal).
 
 ### Options
 
-#### g:srcery_bold
+#### g:srcery\_bold
 
 Enables bold text.
 
 Default: 1
 
-#### g:srcery_italic
+#### g:srcery\_italic
 
 Enables italic text.
 
 Default: gui 1, term 0
 
-#### g:srcery_underline
+#### g:srcery\_underline
 
 Enables underlined text.
 
 Default: 1
 
-#### g:srcery_undercurl
+#### g:srcery\_undercurl
 
 Enables undercurled text.
 
 Default: 1
 
-#### g:srcery_inverse
+#### g:srcery\_inverse
 
 Enable or disable inverse highlighting (foreground becomes background,
 vice versa). This is used for visual selection, search highlights and
@@ -163,13 +163,13 @@ disabled.
 
 Default: 1
 
-#### g:srcery_inverse_matches
+#### g:srcery\_inverse\_matches
 
 Highlight search matches using inverse colors.
 
 Default: 0
 
-#### g:srcery_inverse_match_paren
+#### g:srcery\_inverse\_match\_paren
 
 When enabled will highlight matching delimiters using inverse colors.
 (`:DoMatchParen`)
@@ -178,13 +178,13 @@ Works best with [Rainbow parenthesis](https://github.com/kien/rainbow_parenthese
 
 Default: 0
 
-#### g:srcery_dim_lisp_paren
+#### g:srcery\_dim\_lisp\_paren
 
 Dims lisp dialects delimiters to a fairly dark gray (xgray5 specifically).
 
 Default: 0
 
-#### g:srcery_bg_passthrough
+#### g:srcery\_bg\_passthrough
 
 Lets the terminal control the background color in Vim by setting the background to `NONE`.
 
@@ -196,7 +196,7 @@ terminals.
 
 Default: 0
 
-#### g:srcery_guisp_fallback
+#### g:srcery\_guisp\_fallback
 
 Sets up alternate highlighting for colored underline/undercurl. Some
 environments are unable to color underline, so this setting will set either the
@@ -209,7 +209,7 @@ Default: 'NONE'
 
 Possible Values: 'fg', 'bg'
 
-#### g:srcery_italic_types
+#### g:srcery\_italic\_types
 
 Italicize types if italic is enabled.
 
@@ -218,19 +218,19 @@ Default: 0
 ## Screenshots
 
 viml, bash
-![viml_bash](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/viml_bash.png)
+![viml\_bash](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/viml_bash.png)
 
 clojure, elisp
 ![lisp](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/lisp.png)
 
 c, rust
-![c_rust](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/c_rust.png)
+![c\_rust](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/c_rust.png)
 
 python, js
-![py_js](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/py_js.png)
+![py\_js](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/py_js.png)
 
 git, terminal
-![git_term](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/git_term.png)
+![git\_term](https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/vim/git_term.png)
 
 Typeface used in screenshots is [Iosevka](https://github.com/be5invis/Iosevka)
 

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -315,6 +315,9 @@ call s:HL('SrceryBrightCyan', s:bright_cyan, s:none)
 call s:HL('SrceryBrightBlack', s:bright_black, s:none)
 call s:HL('SrceryBrightWhite', s:bright_white)
 
+call s:HL('SrceryBrightBlueBold', s:bright_blue, s:none, s:bold)
+call s:HL('SrceryBrightYellowBold', s:bright_yellow, s:none, s:bold)
+
 " special
 call s:HL('SrceryOrange', s:orange)
 call s:HL('SrceryBrightOrange', s:bright_orange)
@@ -1153,16 +1156,16 @@ hi! link scalaInterpolation SrceryCyan
 
 call s:HL('markdownItalic', s:bright_white, s:none, s:italic)
 
-hi! link markdownH1 SrceryGreenBold
-hi! link markdownH2 SrceryGreenBold
-hi! link markdownH3 SrceryYellowBold
-hi! link markdownH4 SrceryYellowBold
-hi! link markdownH5 SrceryYellow
-hi! link markdownH6 SrceryYellow
+hi! link markdownH1 SrceryBrightBlueBold
+hi! link markdownH2 SrceryBrightBlueBold
+hi! link markdownH3 SrceryBrightYellowBold
+hi! link markdownH4 SrceryBrightYellowBold
+hi! link markdownH5 SrceryYellowBold
+hi! link markdownH6 SrceryYellowBold
 
-hi! link markdownCode SrceryCyan
-hi! link markdownCodeBlock SrceryCyan
-hi! link markdownCodeDelimiter SrceryCyan
+hi! link markdownCode SrceryWhite
+hi! link markdownCodeBlock SrceryWhite
+hi! link markdownCodeDelimiter SrceryWhite
 
 hi! link markdownBlockquote SrceryBrightBlack
 hi! link markdownListMarker SrceryBrightBlack
@@ -1170,15 +1173,15 @@ hi! link markdownOrderedListMarker SrceryBrightBlack
 hi! link markdownRule SrceryBrightBlack
 hi! link markdownHeadingRule SrceryBrightBlack
 
-hi! link markdownUrlDelimiter SrceryBrightWhite
-hi! link markdownLinkDelimiter SrceryBrightWhite
-hi! link markdownLinkTextDelimiter SrceryBrightWhite
+hi! link markdownUrlDelimiter SrceryBrightBlack
+hi! link markdownLinkDelimiter SrceryBrightBlack
+hi! link markdownLinkTextDelimiter SrceryBrightBlack
 
-hi! link markdownHeadingDelimiter SrceryYellow
-hi! link markdownUrl SrceryMagenta
+hi! link markdownHeadingDelimiter SrceryBrightBlack
+hi! link markdownUrl SrceryBrightGreen
 hi! link markdownUrlTitleDelimiter SrceryGreen
 
-call s:HL('markdownLinkText', s:bright_black, s:none, s:underline)
+call s:HL('markdownLinkText', s:bright_white, s:none, s:underline)
 hi! link markdownIdDeclaration markdownLinkText
 
 " }}}

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -1035,13 +1035,14 @@ hi! link sassIdChar SrceryBrightBlue
 " }}}
 " JavaScript: {{{
 
-hi! link javaScriptMember SrceryBlue
-hi! link javaScriptNull SrceryMagenta
+hi! link javascriptMember SrceryBlue
+hi! link javascriptNull SrceryMagenta
 
-" }}}
-" YAJS: {{{
+hi! link javascriptParens SrceryWhite
+hi! link javascriptBraces SrceryWhite
+hi! link javascriptReserved SrceryOrange
+hi! link javascriptIdentifier SrceryRed
 
-hi! link javascriptParens SrceryBrightCyan
 hi! link javascriptFuncArg Normal
 hi! link javascriptDocComment SrceryGreen
 hi! link javascriptArrayMethod Function
@@ -1050,6 +1051,7 @@ hi! link javascriptStringMethod Function
 hi! link javascriptObjectMethod Function
 hi! link javascriptObjectStaticMethod Function
 hi! link javascriptObjectLabel SrceryBlue
+hi! link javascriptFunction SrceryRed
 
 hi! link javascriptProp SrceryBlue
 
@@ -1058,7 +1060,17 @@ hi! link javascriptOperator SrceryBrightCyan
 hi! link javascriptFuncKeyword SrceryBrightRed
 hi! link javascriptFunctionMethod SrceryYellow
 hi! link javascriptReturn SrceryBrightRed
-hi! link javascriptEndColons Normal
+hi! link javascriptEndColons SrceryWhite
+
+" vim-javascript
+hi! link jsFunction SrceryRed
+hi! link jsImport SrceryRed
+hi! link jsObjectSeparator SrceryWhite
+hi! link jsParens SrceryWhite
+hi! link jsFuncParens SrceryWhite
+hi! link jsNoise SrceryWhite
+hi! link jsEnvComment SrceryBrightBlack
+hi! link jsOperator SrceryBrightCyan
 
 " }}}
 " CoffeeScript: {{{


### PR DESCRIPTION
I've done some revisions on markdown and javascript, mostly markdown.

### Markdown
I used the [plasticboy markdown](https://github.com/plasticboy/vim-markdown) before but I had to switch to [tpope markdown](https://github.com/tpope/vim-markdown), and I disliked how things looked. Markdown is mostly used for prose, so having a ton of color can be a bit distracting in my opinion. 
#### Old markdown
![old-md](https://user-images.githubusercontent.com/4509009/126175865-9c85a452-435e-4b4a-a63b-74c57e61e2d9.png)

#### New markdown
![new-md](https://user-images.githubusercontent.com/4509009/126175993-3e2d041f-45c4-4dd0-b0c6-40dcae2ba011.png)


### Javascript
Second is some javascript revisions, I tried to get builtin and [pangloss javascript](https://github.com/pangloss/vim-javascript) looking somewhat similar, and various minor tweaks.

#### Old builtin javascript
![old-js](https://user-images.githubusercontent.com/4509009/126181895-ea9a297c-4af8-43ba-8b1e-f979364d29ff.png)

#### New builtin javascript
![new-js](https://user-images.githubusercontent.com/4509009/126181948-0a89330f-4c1c-4c60-8981-bf1d7f9fe039.png)

#### Old [pangloss javascript](https://github.com/pangloss/vim-javascript) 
![old-plugin-js](https://user-images.githubusercontent.com/4509009/126176506-92afde87-15b4-40d2-8e86-b4b2b3f20190.png)

### New [pangloss javascript](https://github.com/pangloss/vim-javascript) 
![new-plugin-js](https://user-images.githubusercontent.com/4509009/126176593-262a11bb-bede-416f-a70e-bfabfdda88e8.png)
