### PR TITLE
docs: fix path again for native vim 8 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Put `srcery.vim` in `~/.vim/colors/` (on unix-like systems) or `%userprofile%\vi
 Vim 8 has native support for loading plugins. All you need to do to is to clone
 this repository into `~/.vim/pack/default/opt`.
 
-    git clone https://github.com/srcery-colors/srcery-vim ~/.vim/pack/default/opt
+    git clone https://github.com/srcery-colors/srcery-vim ~/.vim/pack/default/opt/srcery-vim
 
 The same works for Neovim, but you have to clone it into a path where Neovim can
 find it.
 
-    git clone https://github.com/srcery-colors/srcery-vim ~/.config/nvim/plug/default/opt
+    git clone https://github.com/srcery-colors/srcery-vim ~/.config/nvim/plug/default/opt/srcery-vim
 
 ### [dein.vim](https://github.com/Shougo/dein.vim)
 


### PR DESCRIPTION
fix #79.
LONG LIFE OF VI IMPROVED!!!