### PR TITLE
fix: Missing new install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,23 @@ to pad out the color selection, no extra configuration needed.
 
 ### Manually
 
-Put `srcery.vim` in `~/.vim/colors/` (on unix-like systems) or `%userprofile%\vimfiles\colors\` (on Windows).
+Put `srcery.vim` in `~/.vim/colors/` (on unix-like systems) or `%userprofile%\vimfiles\colors\` (on Windows). You can also install with your favourite plugin manager.
+
+Don't forget to set your `runtimepath` correctly, otherwise srcery will not work as it relies on `autoload` functionality.
 
 ### Vim 8
 
-Vim 8 has native support for loading plugins. All you need to do to is to clone
-this repository into `~/.vim/pack/default/opt`.
+Vim 8 has native support for loading plugins by using `packages`. All you need to do to is to clone
+this repository into `~/.vim/pack/themes/opt`.
 
-    git clone https://github.com/srcery-colors/srcery-vim ~/.vim/pack/default/opt/srcery-vim
+    git clone https://github.com/srcery-colors/srcery-vim ~/.vim/pack/themes/opt/srcery-vim
+
+And then set your `.vimrc` accordingly.
+
+```vim
+packadd! srcery-vim
+colorscheme srcery
+```
 
 The same works for Neovim, but you have to clone it into a path where Neovim can
 find it.

--- a/README.md
+++ b/README.md
@@ -56,14 +56,13 @@ to pad out the color selection, no extra configuration needed.
 
 ### Manually
 
-Put `srcery.vim` in `~/.vim/colors/` (on unix-like systems) or `%userprofile%\vimfiles\colors\` (on Windows). You can also install with your favourite plugin manager.
+Download or clone srcery's repository to a location of your choosing and set your `runtimepath` correctly, otherwise srcery will not work as it relies on the `autoload` functionality.
 
-Don't forget to set your `runtimepath` correctly, otherwise srcery will not work as it relies on `autoload` functionality.
+You can also install with your favourite plugin manager.
 
 ### Vim 8
 
-Vim 8 has native support for loading plugins by using `packages`. All you need to do to is to clone
-this repository into `~/.vim/pack/themes/opt`.
+Vim 8 has native support for loading plugins by using `packages`. All you need to do to, is to clone this repository into `~/.vim/pack/themes/opt`.
 
     git clone https://github.com/srcery-colors/srcery-vim ~/.vim/pack/themes/opt/srcery-vim
 
@@ -77,7 +76,7 @@ colorscheme srcery
 The same works for Neovim, but you have to clone it into a path where Neovim can
 find it.
 
-    git clone https://github.com/srcery-colors/srcery-vim ~/.config/nvim/plug/default/opt/srcery-vim
+    git clone https://github.com/srcery-colors/srcery-vim $XDG_CONFIG_HOME/nvim/pack/themes/opt
 
 ### [dein.vim](https://github.com/Shougo/dein.vim)
 

--- a/doc/srcery.txt
+++ b/doc/srcery.txt
@@ -40,17 +40,25 @@ sessions using an editor or terminal emulator.
 
 ==============================================================================
 INSTALLATION						   *srcery-installation*
-
 Put srcery.vim in `~/.vim/colors/` (on unix-like systems) or
-`%userprofile%\vimfiles\colors\` (on Windows).
+`%userprofile%\vimfiles\colors\` (on Windows). You can also install with your
+favourite plugin manager.
+
+Don't forget to set your 'runtimepath' correctly, otherwise srcery will not
+work as it relies on 'autoload' functionality.
 
 							   *srcery-install-vim8*
 
-Vim 8 has native support for loading plugins. All you need to do to is to
-clone this repository into `~/.vim/plug/default/opt`.
+Vim 8 has native support for loading plugins by using |packages|. All you need
+to do to is to clone this repository into `~/.vim/pack/themes/opt`.
 >
 	git clone https://github.com/srcery-colors/srcery-vim \
-		~/.vim/plug/default/opt
+		~/.vim/pack/themes/opt
+<
+And then set your `.vimrc` accordingly.
+>
+	packadd! srcery-vim
+	colorscheme srcery
 <
 
 The same works for Neovim, but you have to clone it into a path where Neovim
@@ -236,7 +244,7 @@ g:srcery_italic_types
 
 					  *srcery-option-hard-black-terminal-bg*
 g:srcery_hard_black_terminal_bg
-	
+
 	If enabled, will set the terminal background in vim to hard black.
 	Note that this currently only works in Vim, not Neovim.
 

--- a/doc/srcery.txt
+++ b/doc/srcery.txt
@@ -40,17 +40,17 @@ sessions using an editor or terminal emulator.
 
 ==============================================================================
 INSTALLATION						   *srcery-installation*
-Put srcery.vim in `~/.vim/colors/` (on unix-like systems) or
-`%userprofile%\vimfiles\colors\` (on Windows). You can also install with your
-favourite plugin manager.
 
-Don't forget to set your 'runtimepath' correctly, otherwise srcery will not
-work as it relies on 'autoload' functionality.
+Download or clone srcery's repository to a location of your choosing and set
+your 'runtimepath' correctly, otherwise srcery will not work as it relies on
+'autoload' functionality.
+
+You can also install with your favourite plugin manager.
 
 							   *srcery-install-vim8*
 
 Vim 8 has native support for loading plugins by using |packages|. All you need
-to do to is to clone this repository into `~/.vim/pack/themes/opt`.
+to do to, is to clone this repository into `~/.vim/pack/themes/opt`.
 >
 	git clone https://github.com/srcery-colors/srcery-vim \
 		~/.vim/pack/themes/opt
@@ -65,7 +65,7 @@ The same works for Neovim, but you have to clone it into a path where Neovim
 can find it.
 >
 	git clone https://github.com/srcery-colors/srcery-vim \
-		~/.config/nvim/plug/default/opt
+		$XDG_CONFIG_HOME/nvim/pack/themes/opt
 <
 
 							   *srcery-install-dein*


### PR DESCRIPTION
Since the new refactor #84 srcery relies on the autoload functionality of vim. This pull request addresses missing explanation on how to install.

Closes #88 
Closes #89 