### PR TITLE
Fix/js vue html issues + feat

### DIFF
--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -22,6 +22,8 @@ hi! link htmlScriptTag SrceryRed
 hi! link htmlTagN SrceryBlue
 hi! link htmlSpecialTagName SrceryBlue
 
+hi! link javaScript Normal
+
 call srcery#helper#Highlight('htmlLink', s:bright_white, s:none, s:underline)
 
 hi! link htmlSpecialChar SrceryYellow

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -4,14 +4,18 @@ endif
 
 " JavaScript: {{{
 
-hi! link javascript Normal
-hi! link javascriptMember SrceryBlue
-hi! link javascriptNull SrceryMagenta
+hi! link javaScript Normal
+hi! link javaScriptMember SrceryBlue
+hi! link javaScriptNull SrceryMagenta
+hi! link javasCriptParens SrceryWhite
+hi! link javaScriptBraces SrceryWhite
+hi! link javaScriptReserved SrceryOrange
+hi! link javaScriptIdentifier SrceryRed
+hi! link javaScriptFunction SrceryRed
+hi! link javaScriptOperator SrceryBrightCyan
 
-hi! link javascriptParens SrceryWhite
-hi! link javascriptBraces SrceryWhite
-hi! link javascriptReserved SrceryOrange
-hi! link javascriptIdentifier SrceryRed
+" }}}
+" YAJS: {{{
 
 hi! link javascriptFuncArg Normal
 hi! link javascriptDocComment SrceryGreen
@@ -21,18 +25,16 @@ hi! link javascriptStringMethod Function
 hi! link javascriptObjectMethod Function
 hi! link javascriptObjectStaticMethod Function
 hi! link javascriptObjectLabel SrceryBlue
-hi! link javascriptFunction SrceryRed
-
 hi! link javascriptProp SrceryBlue
-
 hi! link javascriptVariable SrceryBrightBlue
-hi! link javascriptOperator SrceryBrightCyan
 hi! link javascriptFuncKeyword SrceryBrightRed
 hi! link javascriptFunctionMethod SrceryYellow
 hi! link javascriptReturn SrceryBrightRed
 hi! link javascriptEndColons SrceryWhite
 
-" vim-javascript
+" }}}
+" pangloss/vim-javascript {{{
+
 hi! link jsFunction SrceryRed
 hi! link jsImport SrceryRed
 hi! link jsObjectSeparator SrceryWhite
@@ -43,3 +45,5 @@ hi! link jsEnvComment SrceryBrightBlack
 hi! link jsOperator SrceryBrightCyan
 
 " }}}
+
+" vim: set ts=2 sw=2 tw=78 fdm=marker et :

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -4,6 +4,7 @@ endif
 
 " JavaScript: {{{
 
+hi! link javascript Normal
 hi! link javascriptMember SrceryBlue
 hi! link javascriptNull SrceryMagenta
 

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -10,9 +10,6 @@ hi! link javaScriptNull SrceryMagenta
 hi! link javasCriptParens SrceryWhite
 hi! link javaScriptBraces SrceryWhite
 hi! link javaScriptReserved SrceryOrange
-hi! link javaScriptIdentifier SrceryRed
-hi! link javaScriptFunction SrceryRed
-hi! link javaScriptOperator SrceryBrightCyan
 
 " }}}
 " YAJS: {{{

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -4,7 +4,6 @@ endif
 
 " JavaScript: {{{
 
-hi! link javaScript Normal
 hi! link javaScriptMember SrceryBlue
 hi! link javaScriptNull SrceryMagenta
 hi! link javasCriptParens SrceryWhite


### PR DESCRIPTION
Fix/js vue html issues + feat
=============================

- I linked the hl group `javaScript` to normal. This makes inline `<script>` blocks in html much nicer, and fixes javavscript highlighting in [vim-vue](https://github.com/posva/vim-vue) plugin. 

- I've also sorted and and cleaned up the javascript syntax file

- there is one feat commit here, despite the branch name, it clears some syntax hl groups for javascript, so that it'll fall back to what is defined top level (symbol, statement etc(colors/srcery.vim)) This adds some needed variety to js colors, and brings it more inline with other languages.

> Keeping this as a draft for now, because I can't understand why the html plugin would set `javaScript` to `Special`. I first thought it had something to do with a couple of syntax plugins I used but digging through nvim runtime folders it seems the hlgroup is defined in html syntax file. I've looked at other colorschemes to see if they even set `javaScript` to anything at all and I can't find any, which makes me think its something I'm missing here.