### PR TITLE
fix: return lsp groups

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -438,6 +438,20 @@ if g:srcery_hard_black_terminal_bg == 1 && has('terminal')
 endif
 
 " }}}
+" Neovim LSP: {{{
+
+if has('nvim')
+  hi! link LspDiagnosticsDefaultError SrceryBrightRed
+  hi! link LspDiagnosticsDefaultWarning SrceryBrightYellow
+  hi! link LspDiagnosticsDefaultInformation SrceryBrightGreen
+  hi! link LspDiagnosticsDefaultHint SrceryBrightCyan
+  call s:HL('LspDiagnosticsUnderlineError', s:bright_red, s:none, s:underline)
+  call s:HL('LspDiagnosticsUnderlineWarning', s:bright_yellow, s:none, s:underline)
+  call s:HL('LspDiagnosticsUnderlineInformation', s:bright_green, s:none, s:underline)
+  call s:HL('LspDiagnosticsUnderlineHint', s:bright_cyan, s:none, s:underline)
+endif
+
+" }}}
 
 " Filetype specific -----------------------------------------------------------
 " Diff: {{{


### PR DESCRIPTION
Disappeared in refactor #84, not quite sure why but without this, undercurl reportedly isn't working. closes #93