### PR TITLE
fix: PmenuThumb has the same color of the bar.

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -395,7 +395,7 @@ if v:version >= 700
     call s:HL('PmenuThumb', s:none, s:none)
   else
     call s:HL('PmenuSbar', s:none, s:black)
-    call s:HL('PmenuThumb', s:none, s:black)
+    call s:HL('PmenuThumb', s:none, s:orange)
   endif
 endif
 


### PR DESCRIPTION
PmenuThumb is not visible in, for example, nvim-cmp's completion window. This is due to the fact that the thumb has the same color of the background, rendering it de-facto invisible.