### PR TITLE
Add option to set bg to hard_black for gui.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ slightly earthy tone.
         - [g:srcery\_bg\_passthrough](#gsrcery_bg_passthrough)
         - [g:srcery\_guisp\_fallback](#gsrcery_guisp_fallback)
         - [g:srcery\_italic\_types](#gsrcery_italic_types)
-        - [g:srcery\_hard\_black\_gui\_bg](#gsrcery_hard_black_gui_bg)
+        - [g:srcery\_bg](#gsrcery_bg)
         - [g:srcery\_hard\_black\_terminal\_bg](#gsrcery_hard_black_terminal_bg)
 - [Screenshots](#screenshots)
 - [Plugin support](#plugin-support)
@@ -298,12 +298,12 @@ Italicize types if italic is enabled.
 
 Default: 0
 
-#### g:srcery\_hard\_black\_gui\_bg
+#### g:srcery\_bg
 
-If enabled, and termguicolors is set, Srcery will utilize g:hard_black as the
-background color.
+Background color, specified as an RGB value.
+Note that this will only work with 'set termguicolors' in your config, and that it is mutually exclusive with 'g:srcery_hard_black_terminal_bg'.
 
-Default: 0
+Default: 'g:srcery_black'
 
 #### g:srcery\_hard\_black\_terminal\_bg
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ slightly earthy tone.
         - [g:srcery\_bg\_passthrough](#gsrcery_bg_passthrough)
         - [g:srcery\_guisp\_fallback](#gsrcery_guisp_fallback)
         - [g:srcery\_italic\_types](#gsrcery_italic_types)
+        - [g:srcery\_hard\_black\_gui\_bg](#gsrcery_hard_black_gui_bg)
         - [g:srcery\_hard\_black\_terminal\_bg](#gsrcery_hard_black_terminal_bg)
 - [Screenshots](#screenshots)
 - [Plugin support](#plugin-support)
@@ -294,6 +295,13 @@ Possible Values: 'fg', 'bg'
 #### g:srcery\_italic\_types
 
 Italicize types if italic is enabled.
+
+Default: 0
+
+#### g:srcery\_hard\_black\_gui\_bg
+
+If enabled, and termguicolors is set, Srcery will utilize g:hard_black as the
+background color.
 
 Default: 0
 

--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -26,22 +26,12 @@ call srcery#helper#Highlight('htmlLink', s:bright_white, s:none, s:underline)
 
 hi! link htmlSpecialChar SrceryYellow
 
-if g:srcery_bg_passthrough == 1 && !has('gui_running')
-  call srcery#helper#Highlight('htmlBold', s:bright_white, s:none, s:bold)
-  call srcery#helper#Highlight('htmlBoldUnderline', s:bright_white, s:none, s:bold . s:underline)
-  call srcery#helper#Highlight('htmlBoldItalic', s:bright_white, s:none, s:bold . s:italic)
-  call srcery#helper#Highlight('htmlBoldUnderlineItalic', s:bright_white, s:none, s:bold . s:underline . s:italic)
-  call srcery#helper#Highlight('htmlUnderline', s:bright_white, s:none, s:underline)
-  call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, s:none, s:underline . s:italic)
-  call srcery#helper#Highlight('htmlItalic', s:bright_white, s:none, s:italic)
-else
-  call srcery#helper#Highlight('htmlBold', s:bright_white, [g:srcery_bg, 0], s:bold)
-  call srcery#helper#Highlight('htmlBoldUnderline', s:bright_white, [g:srcery_bg, 0], s:bold . s:underline)
-  call srcery#helper#Highlight('htmlBoldItalic', s:bright_white, [g:srcery_bg, 0], s:bold . s:italic)
-  call srcery#helper#Highlight('htmlBoldUnderlineItalic', s:bright_white, [g:srcery_bg, 0], s:bold . s:underline . s:italic)
-  call srcery#helper#Highlight('htmlUnderline', s:bright_white, [g:srcery_bg, 0], s:underline)
-  call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, [g:srcery_bg, 0], s:underline . s:italic)
-  call srcery#helper#Highlight('htmlItalic', s:bright_white, [g:srcery_bg, 0], s:italic)
-endif
+call srcery#helper#Highlight('htmlBold', s:bright_white, g:srcery_bg, s:bold)
+call srcery#helper#Highlight('htmlBoldUnderline', s:bright_white, g:srcery_bg, s:bold . s:underline)
+call srcery#helper#Highlight('htmlBoldItalic', s:bright_white, g:srcery_bg, s:bold . s:italic)
+call srcery#helper#Highlight('htmlBoldUnderlineItalic', s:bright_white, g:srcery_bg, s:bold . s:underline . s:italic)
+call srcery#helper#Highlight('htmlUnderline', s:bright_white, g:srcery_bg, s:underline)
+call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, g:srcery_bg, s:underline . s:italic)
+call srcery#helper#Highlight('htmlItalic', s:bright_white, g:srcery_bg, s:italic)
 
 " }}}

--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -5,6 +5,7 @@ endif
 let s:none = g:srcery#palette.none
 let s:black = g:srcery#palette.black
 let s:bright_white = g:srcery#palette.bright_white
+let s:hard_black = g:srcery#palette.hard_black
 
 let s:bold = g:srcery#palette.bold
 let s:italic = g:srcery#palette.italic
@@ -34,6 +35,14 @@ if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call srcery#helper#Highlight('htmlUnderline', s:bright_white, s:none, s:underline)
   call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, s:none, s:underline . s:italic)
   call srcery#helper#Highlight('htmlItalic', s:bright_white, s:none, s:italic)
+elseif g:srcery_hard_black_gui_bg ==1
+  call srcery#helper#Highlight('htmlBold', s:bright_white, s:hard_black, s:bold)
+  call srcery#helper#Highlight('htmlBoldUnderline', s:bright_white, s:hard_black, s:bold . s:underline)
+  call srcery#helper#Highlight('htmlBoldItalic', s:bright_white, s:hard_black, s:bold . s:italic)
+  call srcery#helper#Highlight('htmlBoldUnderlineItalic', s:bright_white, s:hard_black, s:bold . s:underline . s:italic)
+  call srcery#helper#Highlight('htmlUnderline', s:bright_white, s:hard_black, s:underline)
+  call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, s:hard_black, s:underline . s:italic)
+  call srcery#helper#Highlight('htmlItalic', s:bright_white, s:hard_black, s:italic)
 else
   call srcery#helper#Highlight('htmlBold', s:bright_white, s:black, s:bold)
   call srcery#helper#Highlight('htmlBoldUnderline', s:bright_white, s:black, s:bold . s:underline)

--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -5,7 +5,6 @@ endif
 let s:none = g:srcery#palette.none
 let s:black = g:srcery#palette.black
 let s:bright_white = g:srcery#palette.bright_white
-let s:hard_black = g:srcery#palette.hard_black
 
 let s:bold = g:srcery#palette.bold
 let s:italic = g:srcery#palette.italic
@@ -35,22 +34,14 @@ if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call srcery#helper#Highlight('htmlUnderline', s:bright_white, s:none, s:underline)
   call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, s:none, s:underline . s:italic)
   call srcery#helper#Highlight('htmlItalic', s:bright_white, s:none, s:italic)
-elseif g:srcery_hard_black_gui_bg ==1
-  call srcery#helper#Highlight('htmlBold', s:bright_white, s:hard_black, s:bold)
-  call srcery#helper#Highlight('htmlBoldUnderline', s:bright_white, s:hard_black, s:bold . s:underline)
-  call srcery#helper#Highlight('htmlBoldItalic', s:bright_white, s:hard_black, s:bold . s:italic)
-  call srcery#helper#Highlight('htmlBoldUnderlineItalic', s:bright_white, s:hard_black, s:bold . s:underline . s:italic)
-  call srcery#helper#Highlight('htmlUnderline', s:bright_white, s:hard_black, s:underline)
-  call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, s:hard_black, s:underline . s:italic)
-  call srcery#helper#Highlight('htmlItalic', s:bright_white, s:hard_black, s:italic)
 else
-  call srcery#helper#Highlight('htmlBold', s:bright_white, s:black, s:bold)
-  call srcery#helper#Highlight('htmlBoldUnderline', s:bright_white, s:black, s:bold . s:underline)
-  call srcery#helper#Highlight('htmlBoldItalic', s:bright_white, s:black, s:bold . s:italic)
-  call srcery#helper#Highlight('htmlBoldUnderlineItalic', s:bright_white, s:black, s:bold . s:underline . s:italic)
-  call srcery#helper#Highlight('htmlUnderline', s:bright_white, s:black, s:underline)
-  call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, s:black, s:underline . s:italic)
-  call srcery#helper#Highlight('htmlItalic', s:bright_white, s:black, s:italic)
+  call srcery#helper#Highlight('htmlBold', s:bright_white, [g:srcery_bg, 0], s:bold)
+  call srcery#helper#Highlight('htmlBoldUnderline', s:bright_white, [g:srcery_bg, 0], s:bold . s:underline)
+  call srcery#helper#Highlight('htmlBoldItalic', s:bright_white, [g:srcery_bg, 0], s:bold . s:italic)
+  call srcery#helper#Highlight('htmlBoldUnderlineItalic', s:bright_white, [g:srcery_bg, 0], s:bold . s:underline . s:italic)
+  call srcery#helper#Highlight('htmlUnderline', s:bright_white, [g:srcery_bg, 0], s:underline)
+  call srcery#helper#Highlight('htmlUnderlineItalic', s:bright_white, [g:srcery_bg, 0], s:underline . s:italic)
+  call srcery#helper#Highlight('htmlItalic', s:bright_white, [g:srcery_bg, 0], s:italic)
 endif
 
 " }}}

--- a/autoload/srcery.vim
+++ b/autoload/srcery.vim
@@ -152,6 +152,10 @@ if !exists('g:srcery_italic_types')
   let g:srcery_italic_types=0
 endif
 
+if !exists('g:srcery_hard_black_gui_bg')
+  let g:srcery_hard_black_gui_bg=0
+endif
+
 if !exists('g:srcery_hard_black_terminal_bg')
   let g:srcery_hard_black_terminal_bg=1
 endif

--- a/autoload/srcery.vim
+++ b/autoload/srcery.vim
@@ -152,8 +152,8 @@ if !exists('g:srcery_italic_types')
   let g:srcery_italic_types=0
 endif
 
-if !exists('g:srcery_hard_black_gui_bg')
-  let g:srcery_hard_black_gui_bg=0
+if !exists('g:srcery_bg')
+  let g:srcery_bg=g:srcery_black
 endif
 
 if !exists('g:srcery_hard_black_terminal_bg')

--- a/autoload/srcery.vim
+++ b/autoload/srcery.vim
@@ -155,7 +155,7 @@ elseif (index(g:srcery_bg, 'DEFAULT') >= 0) || (index(g:srcery_bg, 'NONE') >= 0 
   "Defaults should be set if the user specifies it, or if the background is set as 'NONE' whilst the gui is running.
   for i in [0, 1]
     if g:srcery_bg[i] == 'DEFAULT' || (g:srcery_bg[i] == 'NONE' && has('gui_running'))
-      let g:srcery_bg[i] = g:srcery_black
+      let g:srcery_bg[i] = (i==1 ? 0 : g:srcery_black)
     endif
   endfor
 endif

--- a/autoload/srcery.vim
+++ b/autoload/srcery.vim
@@ -153,11 +153,15 @@ if !exists('g:srcery_italic_types')
 endif
 
 if !exists('g:srcery_bg')
-  let g:srcery_bg=g:srcery_black
-endif
-
-if !exists('g:srcery_hard_black_terminal_bg')
-  let g:srcery_hard_black_terminal_bg=1
+  "Sets the default color for both guisp and cterm backgrounds.
+  let g:srcery_bg=[g:srcery_black, 0]
+elseif (index(g:srcery_bg, 'DEFAULT') >= 0) || (index(g:srcery_bg, 'NONE') >= 0 && has('gui_running'))
+  "Defaults should be set if the user specifies it, or if the background is set as 'NONE' whilst the gui is running.
+  for i in [0, 1]
+    if g:srcery_bg[i] == 'DEFAULT' || (g:srcery_bg[i] == 'NONE' && has('gui_running'))
+      let g:srcery_bg[i] = g:srcery_black
+    endif
+  endfor
 endif
 
 " }}}

--- a/autoload/srcery.vim
+++ b/autoload/srcery.vim
@@ -116,10 +116,6 @@ if !exists('g:srcery_italic')
   endif
 endif
 
-if !exists('g:srcery_bg_passthrough')
-  let g:srcery_bg_passthrough=0
-endif
-
 if !exists('g:srcery_undercurl')
   let g:srcery_undercurl=1
 endif

--- a/autoload/srcery.vim
+++ b/autoload/srcery.vim
@@ -154,7 +154,7 @@ if !exists('g:srcery_bg')
 elseif (index(g:srcery_bg, 'DEFAULT') >= 0) || (index(g:srcery_bg, 'NONE') >= 0 && has('gui_running'))
   "Defaults should be set if the user specifies it, or if the background is set as 'NONE' whilst the gui is running.
   for i in [0, 1]
-    if g:srcery_bg[i] == 'DEFAULT' || (g:srcery_bg[i] == 'NONE' && has('gui_running'))
+    if g:srcery_bg[i] ==# 'DEFAULT' || (g:srcery_bg[i] ==# 'NONE' && has('gui_running'))
       let g:srcery_bg[i] = (i==1 ? 0 : g:srcery_black)
     endif
   endfor

--- a/autoload/srcery.vim
+++ b/autoload/srcery.vim
@@ -160,6 +160,10 @@ elseif (index(g:srcery_bg, 'DEFAULT') >= 0) || (index(g:srcery_bg, 'NONE') >= 0 
   endfor
 endif
 
+if !exists('g:srcery_hard_black_terminal_bg')
+  let g:srcery_hard_black_terminal_bg=1
+endif
+
 " }}}
 " }}}
 " Palette: {{{

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -171,11 +171,7 @@ call s:HL('SrceryXgray6', s:xgray6)
 
 " Normal text
 "
-if g:srcery_bg_passthrough == 1 && !has('gui_running')
-  call s:HL('Normal', s:bright_white, s:none)
-else
-  call s:HL('Normal', s:bright_white, [g:srcery_bg, 0])
-endif
+call s:HL('Normal', s:bright_white, g:srcery_bg)
 
 if v:version >= 700
   " Screen line that the cursor is
@@ -206,11 +202,7 @@ if v:version >= 703
   call s:HL('Conceal', s:blue, s:none)
 
   " Line number of CursorLine
-  if g:srcery_bg_passthrough == 1 && !has('gui_running')
-    call s:HL('CursorLineNr', s:yellow, s:none)
-  else
-    call s:HL('CursorLineNr', s:yellow, [g:srcery_bg, 0])
-  endif
+  call s:HL('CursorLineNr', s:yellow, g:srcery_bg)
 
 endif
 
@@ -237,19 +229,11 @@ call s:HL('Underlined', s:blue, s:none, s:underline)
 
 call s:HL('StatusLine',   s:bright_white, s:xgray2)
 
-if g:srcery_bg_passthrough == 1 && !has('gui_running')
-  call s:HL('StatusLineNC', s:bright_black, s:none, s:underline)
-
-  " The column separating vertically split windows
-  call s:HL('VertSplit', s:bright_white, s:none)
-
-  " Current match in wildmenu completion
-  call s:HL('WildMenu', s:blue, s:none, s:bold)
-else
-  call s:HL('StatusLineNC', s:bright_black, [g:srcery_bg, 0], s:underline)
-  call s:HL('VertSplit', s:bright_white, [g:srcery_bg, 0])
-  call s:HL('WildMenu', s:blue, [g:srcery_bg, 0], s:bold)
-endif
+call s:HL('StatusLineNC', s:bright_black, g:srcery_bg, s:underline)
+" The column separating vertically split windows
+call s:HL('VertSplit', s:bright_white, g:srcery_bg)
+" Current match in wildmenu completion
+call s:HL('WildMenu', s:blue, g:srcery_bg, s:bold)
 
 " Directory names, special names in listing
 hi! link Directory SrceryGreenBold
@@ -274,19 +258,13 @@ hi! link WarningMsg SrceryRedBold
 " Line number for :number and :# commands
 call s:HL('LineNr', s:bright_black)
 
-if g:srcery_bg_passthrough == 1 && !has('gui_running')
-  " Column where signs are displayed
-  " TODO Possibly need to fix  SignColumn
-  call s:HL('SignColumn', s:none, s:none)
-  " Line used for closed folds
-  call s:HL('Folded', s:bright_black, s:none, s:italic)
-  " Column where folds are displayed
-  call s:HL('FoldColumn', s:bright_black, s:none)
-else
-  call s:HL('SignColumn', s:none, [g:srcery_bg, 0])
-  call s:HL('Folded', s:bright_black, [g:srcery_bg, 0], s:italic)
-  call s:HL('FoldColumn', s:bright_black, [g:srcery_bg, 0])
-endif
+" Column where signs are displayed
+" TODO Possibly need to fix  SignColumn
+call s:HL('SignColumn', s:none, g:srcery_bg)
+" Line used for closed folds
+call s:HL('Folded', s:bright_black, g:srcery_bg, s:italic)
+" Column where folds are displayed
+call s:HL('FoldColumn', s:bright_black, g:srcery_bg)
 
 " }}}
 " Cursor: {{{
@@ -307,11 +285,7 @@ hi! link Special SrceryOrange
 
 call s:HL('Comment', s:bright_black, s:none, s:italic)
 
-if g:srcery_bg_passthrough == 1 && !has('gui_running')
-  call s:HL('Todo', s:bright_white, s:none, s:bold . s:italic)
-else
-  call s:HL('Todo', s:bright_white, [g:srcery_bg, 0], s:bold . s:italic)
-endif
+call s:HL('Todo', s:bright_white, g:srcery_bg, s:bold . s:italic)
 
 call s:HL('Error', s:bright_white, s:red, s:bold)
 
@@ -388,31 +362,19 @@ if v:version >= 700
   " Popup menu: selected item
   call s:HL('PmenuSel', s:bright_white, s:blue, s:bold)
 
-  if g:srcery_bg_passthrough == 1 && !has('gui_running')
-    " Popup menu: scrollbar
-    call s:HL('PmenuSbar', s:none, s:none)
-    " Popup menu: scrollbar thumb
-    call s:HL('PmenuThumb', s:none, s:none)
-  else
-    call s:HL('PmenuSbar', s:none, [g:srcery_bg, 0])
-    call s:HL('PmenuThumb', s:none, s:orange)
-  endif
+  " Popup menu: scrollbar
+  call s:HL('PmenuSbar', s:none, g:srcery_bg)
+  " Popup menu: scrollbar thumb
+  call s:HL('PmenuThumb', s:none, s:orange)
 endif
 
 " }}}
 " Diffs: {{{
 
-if g:srcery_bg_passthrough == 1 && !has('gui_running')
-  call s:HL('DiffDelete', s:red, s:none)
-  call s:HL('DiffAdd',    s:green, s:none)
-  call s:HL('DiffChange', s:cyan, s:none)
-  call s:HL('DiffText',   s:yellow, s:none)
-else
-  call s:HL('DiffDelete', s:red, [g:srcery_bg, 0])
-  call s:HL('DiffAdd',    s:green, [g:srcery_bg, 0])
-  call s:HL('DiffChange', s:cyan, [g:srcery_bg, 0])
-  call s:HL('DiffText',   s:yellow, [g:srcery_bg, 0])
-endif
+call s:HL('DiffDelete', s:red, g:srcery_bg)
+call s:HL('DiffAdd',    s:green, g:srcery_bg)
+call s:HL('DiffChange', s:cyan, g:srcery_bg)
+call s:HL('DiffText',   s:yellow, g:srcery_bg)
 
 " }}}
 " Spelling: {{{
@@ -426,15 +388,6 @@ if has('spell')
   call s:HL('SpellLocal', s:none, s:none, s:undercurl, s:cyan)
   " Rare word
   call s:HL('SpellRare',  s:none, s:none, s:undercurl, s:magenta)
-endif
-
-" }}}
-" Terminal: {{{
-
-if g:srcery_hard_black_terminal_bg == 1 && has('terminal')
-  " Must set an explicit background as NONE won't work
-  " Therefore not useful with transparent background option
-  call s:HL('Terminal', s:bright_white, s:hard_black)
 endif
 
 " }}}

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -173,10 +173,8 @@ call s:HL('SrceryXgray6', s:xgray6)
 "
 if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('Normal', s:bright_white, s:none)
-elseif g:srcery_hard_black_gui_bg == 1
-  call s:HL('Normal', s:bright_white, s:hard_black)
 else
-  call s:HL('Normal', s:bright_white, s:black)
+  call s:HL('Normal', s:bright_white, [g:srcery_bg, 0])
 endif
 
 if v:version >= 700
@@ -210,10 +208,8 @@ if v:version >= 703
   " Line number of CursorLine
   if g:srcery_bg_passthrough == 1 && !has('gui_running')
     call s:HL('CursorLineNr', s:yellow, s:none)
-  elseif g:srcery_hard_black_gui_bg == 1
-    call s:HL('CursorLineNr', s:yellow, s:hard_black)
   else
-    call s:HL('CursorLineNr', s:yellow, s:black)
+    call s:HL('CursorLineNr', s:yellow, [g:srcery_bg, 0])
   endif
 
 endif
@@ -249,14 +245,10 @@ if g:srcery_bg_passthrough == 1 && !has('gui_running')
 
   " Current match in wildmenu completion
   call s:HL('WildMenu', s:blue, s:none, s:bold)
-elseif g:srcery_hard_black_gui_bg == 1
-  call s:HL('StatusLineNC', s:bright_black, s:hard_black, s:underline)
-  call s:HL('VertSplit', s:bright_white, s:hard_black)
-  call s:HL('WildMenu', s:blue, s:hard_black, s:bold)
 else
-  call s:HL('StatusLineNC', s:bright_black, s:black, s:underline)
-  call s:HL('VertSplit', s:bright_white, s:black)
-  call s:HL('WildMenu', s:blue, s:black, s:bold)
+  call s:HL('StatusLineNC', s:bright_black, [g:srcery_bg, 0], s:underline)
+  call s:HL('VertSplit', s:bright_white, [g:srcery_bg, 0])
+  call s:HL('WildMenu', s:blue, [g:srcery_bg, 0], s:bold)
 endif
 
 " Directory names, special names in listing
@@ -290,14 +282,10 @@ if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('Folded', s:bright_black, s:none, s:italic)
   " Column where folds are displayed
   call s:HL('FoldColumn', s:bright_black, s:none)
-elseif g:srcery_hard_black_gui_bg == 1
-  call s:HL('SignColumn', s:none, s:hard_black)
-  call s:HL('Folded', s:bright_black, s:hard_black, s:italic)
-  call s:HL('FoldColumn', s:bright_black, s:hard_black)
 else
-  call s:HL('SignColumn', s:none, s:black)
-  call s:HL('Folded', s:bright_black, s:black, s:italic)
-  call s:HL('FoldColumn', s:bright_black, s:black)
+  call s:HL('SignColumn', s:none, [g:srcery_bg, 0])
+  call s:HL('Folded', s:bright_black, [g:srcery_bg, 0], s:italic)
+  call s:HL('FoldColumn', s:bright_black, [g:srcery_bg, 0])
 endif
 
 " }}}
@@ -321,10 +309,8 @@ call s:HL('Comment', s:bright_black, s:none, s:italic)
 
 if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('Todo', s:bright_white, s:none, s:bold . s:italic)
-elseif g:srcery_hard_black_gui_bg == 1
-  call s:HL('Todo', s:bright_white, s:hard_black, s:bold . s:italic)
 else
-  call s:HL('Todo', s:bright_white, s:black, s:bold . s:italic)
+  call s:HL('Todo', s:bright_white, [g:srcery_bg, 0], s:bold . s:italic)
 endif
 
 call s:HL('Error', s:bright_white, s:red, s:bold)
@@ -407,11 +393,8 @@ if v:version >= 700
     call s:HL('PmenuSbar', s:none, s:none)
     " Popup menu: scrollbar thumb
     call s:HL('PmenuThumb', s:none, s:none)
-  elseif g:srcery_hard_black_gui_bg == 1
-    call s:HL('PmenuSbar', s:none, s:hard_black)
-    call s:HL('PmenuThumb', s:none, s:orange)
   else
-    call s:HL('PmenuSbar', s:none, s:black)
+    call s:HL('PmenuSbar', s:none, [g:srcery_bg, 0])
     call s:HL('PmenuThumb', s:none, s:orange)
   endif
 endif
@@ -424,16 +407,11 @@ if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('DiffAdd',    s:green, s:none)
   call s:HL('DiffChange', s:cyan, s:none)
   call s:HL('DiffText',   s:yellow, s:none)
-elseif g:srcery_hard_black_gui_bg == 1
-  call s:HL('DiffDelete', s:red, s:hard_black)
-  call s:HL('DiffAdd',    s:green, s:hard_black)
-  call s:HL('DiffChange', s:cyan, s:hard_black)
-  call s:HL('DiffText',   s:yellow, s:hard_black)
 else
-  call s:HL('DiffDelete', s:red, s:black)
-  call s:HL('DiffAdd',    s:green, s:black)
-  call s:HL('DiffChange', s:cyan, s:black)
-  call s:HL('DiffText',   s:yellow, s:black)
+  call s:HL('DiffDelete', s:red, [g:srcery_bg, 0])
+  call s:HL('DiffAdd',    s:green, [g:srcery_bg, 0])
+  call s:HL('DiffChange', s:cyan, [g:srcery_bg, 0])
+  call s:HL('DiffText',   s:yellow, [g:srcery_bg, 0])
 endif
 
 " }}}

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -391,6 +391,14 @@ if has('spell')
 endif
 
 " }}}
+" Terminal: {{{
+
+if g:srcery_hard_black_terminal_bg == 1 && has('terminal')
+  " Must set an explicit background as NONE won't work
+  " Therefore not useful with transparent background option
+  call s:HL('Terminal', s:bright_white, s:hard_black)
+endif
+" }}}
 " Neovim LSP: {{{
 
 if has('nvim')

--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -173,7 +173,9 @@ call s:HL('SrceryXgray6', s:xgray6)
 "
 if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('Normal', s:bright_white, s:none)
- else
+elseif g:srcery_hard_black_gui_bg == 1
+  call s:HL('Normal', s:bright_white, s:hard_black)
+else
   call s:HL('Normal', s:bright_white, s:black)
 endif
 
@@ -208,6 +210,8 @@ if v:version >= 703
   " Line number of CursorLine
   if g:srcery_bg_passthrough == 1 && !has('gui_running')
     call s:HL('CursorLineNr', s:yellow, s:none)
+  elseif g:srcery_hard_black_gui_bg == 1
+    call s:HL('CursorLineNr', s:yellow, s:hard_black)
   else
     call s:HL('CursorLineNr', s:yellow, s:black)
   endif
@@ -245,6 +249,10 @@ if g:srcery_bg_passthrough == 1 && !has('gui_running')
 
   " Current match in wildmenu completion
   call s:HL('WildMenu', s:blue, s:none, s:bold)
+elseif g:srcery_hard_black_gui_bg == 1
+  call s:HL('StatusLineNC', s:bright_black, s:hard_black, s:underline)
+  call s:HL('VertSplit', s:bright_white, s:hard_black)
+  call s:HL('WildMenu', s:blue, s:hard_black, s:bold)
 else
   call s:HL('StatusLineNC', s:bright_black, s:black, s:underline)
   call s:HL('VertSplit', s:bright_white, s:black)
@@ -282,6 +290,10 @@ if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('Folded', s:bright_black, s:none, s:italic)
   " Column where folds are displayed
   call s:HL('FoldColumn', s:bright_black, s:none)
+elseif g:srcery_hard_black_gui_bg == 1
+  call s:HL('SignColumn', s:none, s:hard_black)
+  call s:HL('Folded', s:bright_black, s:hard_black, s:italic)
+  call s:HL('FoldColumn', s:bright_black, s:hard_black)
 else
   call s:HL('SignColumn', s:none, s:black)
   call s:HL('Folded', s:bright_black, s:black, s:italic)
@@ -309,6 +321,8 @@ call s:HL('Comment', s:bright_black, s:none, s:italic)
 
 if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('Todo', s:bright_white, s:none, s:bold . s:italic)
+elseif g:srcery_hard_black_gui_bg == 1
+  call s:HL('Todo', s:bright_white, s:hard_black, s:bold . s:italic)
 else
   call s:HL('Todo', s:bright_white, s:black, s:bold . s:italic)
 endif
@@ -393,6 +407,9 @@ if v:version >= 700
     call s:HL('PmenuSbar', s:none, s:none)
     " Popup menu: scrollbar thumb
     call s:HL('PmenuThumb', s:none, s:none)
+  elseif g:srcery_hard_black_gui_bg == 1
+    call s:HL('PmenuSbar', s:none, s:hard_black)
+    call s:HL('PmenuThumb', s:none, s:orange)
   else
     call s:HL('PmenuSbar', s:none, s:black)
     call s:HL('PmenuThumb', s:none, s:orange)
@@ -407,6 +424,11 @@ if g:srcery_bg_passthrough == 1 && !has('gui_running')
   call s:HL('DiffAdd',    s:green, s:none)
   call s:HL('DiffChange', s:cyan, s:none)
   call s:HL('DiffText',   s:yellow, s:none)
+elseif g:srcery_hard_black_gui_bg == 1
+  call s:HL('DiffDelete', s:red, s:hard_black)
+  call s:HL('DiffAdd',    s:green, s:hard_black)
+  call s:HL('DiffChange', s:cyan, s:hard_black)
+  call s:HL('DiffText',   s:yellow, s:hard_black)
 else
   call s:HL('DiffDelete', s:red, s:black)
   call s:HL('DiffAdd',    s:green, s:black)

--- a/doc/srcery.txt
+++ b/doc/srcery.txt
@@ -28,6 +28,7 @@ Options					|srcery-options|
 	g:srcery_bg_passthrough 	|srcery-option-bg-passthrough|
 	g:srcery_guisp_fallback 	|srcery-option-guisp-fallback|
 	g:srcery_italic_types 		|srcery-option-italic-types|
+	g:srcery_hard_black_gui_bg	srcery-option-hard-black-gui-bg
 	g:srcery_hard_black_terminal_bg |srcery-option-hard-black-terminal-bg|
 
 ==============================================================================
@@ -239,6 +240,14 @@ g:srcery_guisp_fallback
 g:srcery_italic_types
 
 	Italicize types if italic is enabled.
+
+	Default: 0
+
+					       srcery-option-hard-black-gui-bg
+g:srcery_hard_black_gui_bg
+
+	If enabled, and termguicolors is set, Srcery will utilize g:hard_black
+	as the background color.
 
 	Default: 0
 

--- a/doc/srcery.txt
+++ b/doc/srcery.txt
@@ -28,7 +28,7 @@ Options					|srcery-options|
 	g:srcery_bg_passthrough 	|srcery-option-bg-passthrough|
 	g:srcery_guisp_fallback 	|srcery-option-guisp-fallback|
 	g:srcery_italic_types 		|srcery-option-italic-types|
-	g:srcery_hard_black_gui_bg	srcery-option-hard-black-gui-bg
+	g:srcery_hard_black_gui_bg	|srcery-option-hard-black-gui-bg|
 	g:srcery_hard_black_terminal_bg |srcery-option-hard-black-terminal-bg|
 
 ==============================================================================
@@ -243,7 +243,7 @@ g:srcery_italic_types
 
 	Default: 0
 
-					       srcery-option-hard-black-gui-bg
+					       *srcery-option-hard-black-gui-bg*
 g:srcery_hard_black_gui_bg
 
 	If enabled, and termguicolors is set, Srcery will utilize g:hard_black

--- a/doc/srcery.txt
+++ b/doc/srcery.txt
@@ -28,7 +28,7 @@ Options					|srcery-options|
 	g:srcery_bg_passthrough 	|srcery-option-bg-passthrough|
 	g:srcery_guisp_fallback 	|srcery-option-guisp-fallback|
 	g:srcery_italic_types 		|srcery-option-italic-types|
-	g:srcery_hard_black_gui_bg	|srcery-option-hard-black-gui-bg|
+	g:srcery_bg			|srcery-option-bg|
 	g:srcery_hard_black_terminal_bg |srcery-option-hard-black-terminal-bg|
 
 ==============================================================================
@@ -243,13 +243,12 @@ g:srcery_italic_types
 
 	Default: 0
 
-					       *srcery-option-hard-black-gui-bg*
-g:srcery_hard_black_gui_bg
+							 	     *srcery-bg*
+g:srcery_bg
+	Background color, specified as an RGB value.
+	Note that this will only work with `set termguicolors` in your config, and that it is mutually exclusive with `g:srcery_hard_black_terminal_bg`.
 
-	If enabled, and termguicolors is set, Srcery will utilize g:hard_black
-	as the background color.
-
-	Default: 0
+	Default: `g:srcery_black`
 
 					  *srcery-option-hard-black-terminal-bg*
 g:srcery_hard_black_terminal_bg


### PR DESCRIPTION
Srcery already has a vim-only option to set the terminal background to hard_black. This commit adds another option, g:srcery_hard_black_gui_bg, compatible with the termguicolors (both Vim and Neovim) set-option.