### PR TITLE
fix: define NormalFloat and FloatBorder

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -173,6 +173,9 @@ call s:HL('SrceryXgray6', s:xgray6)
 "
 call s:HL('Normal', s:bright_white, g:srcery_bg)
 
+call s:HL('NormalFloat', s:bright_white, g:srcery_bg)
+call s:HL('FloatBorder', s:white, g:srcery_bg)
+
 if v:version >= 700
   " Screen line that the cursor is
   call s:HL('CursorLine',   s:none, s:xgray2)


### PR DESCRIPTION
This brings popup windows more in line with each other. The change was prompted by `ChatGPT.nvim` plugin that use telescope as a dependency, but the borders looked off.

`NormalFloat` was linked to `Pmenu`, `Pmenu` is used for completion, and needs to be a different background color than NormalFloat, so I set NormalFloat to srcery_black

`FloatBorder` was linked via `FloatBorder` -> `WinSeparator` -> `VertSplit` which is set to `bright_white`, but Telescope uses white as the border color, so I define that for `FloatBorder` as well

```viml
call s:HL('VertSplit', s:bright_white, g:srcery_bg)
```