### PR TITLE
fix: link Operator to SrceryBrightWhite

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -303,7 +303,7 @@ hi! link Label SrceryRed
 " try, catch, throw
 hi! link Exception SrceryRed
 " sizeof, "+", "*", etc.
-hi! link Operator Normal
+hi! link Operator SrceryBrightWhite
 " Any other keyword
 hi! link Keyword SrceryRed
 


### PR DESCRIPTION
Fixes #112

When linking operator to normal, it'll set the background as well, which we don't want.

@flaamjab can you confirm this is working for you?