### PR TITLE
fix: no contrast issue for lsp popups

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -173,7 +173,6 @@ call s:HL('SrceryXgray6', s:xgray6)
 "
 call s:HL('Normal', s:bright_white, g:srcery_bg)
 
-call s:HL('NormalFloat', s:bright_white, g:srcery_bg)
 call s:HL('FloatBorder', s:white, g:srcery_bg)
 
 if v:version >= 700


### PR DESCRIPTION
Issue was introduced with 2e9b1d4, defining NormalFloat to srcery_bg was a bad idea and broke other popups, due to lacking background contrast.

I left in the border fix though, so that popup borders match what's configured for telescope.

This still leaves some plugin borders looking a bit off, especially if they configure the background to something other than NormalFloat.

Fixes: #115