### PR TITLE
Fix/treesitter markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ slightly earthy tone.
         - [g:srcery\_italic](#gsrcery_italic)
         - [g:srcery\_underline](#gsrcery_underline)
         - [g:srcery\_undercurl](#gsrcery_undercurl)
+        - [g:srcery\_strikethrough](#gsrcery_strikethrough)
         - [g:srcery\_inverse](#gsrcery_inverse)
         - [g:srcery\_inverse\_matches](#gsrcery_inverse_matches)
         - [g:srcery\_inverse\_match\_paren](#gsrcery_inverse_match_paren)
@@ -239,6 +240,12 @@ Default: 1
 #### g:srcery\_undercurl
 
 Enables undercurled text.
+
+Default: 1
+
+#### g:srcery\_strikethrough
+
+Enables strikethrough text.
 
 Default: 1
 

--- a/after/plugin/srcery.vim
+++ b/after/plugin/srcery.vim
@@ -265,13 +265,13 @@ if has('nvim')
       highlight! link @text.strong TSStrong
       highlight! link @text.emphasis TSEmphasis
       highlight! link @text.underline TSUnderline
-      highlight! link @text.warning TSWarning 
-      highlight! link @text.danger TSDanger 
-      highlight! link @constant.builtin TSConstBuiltin 
-      highlight! link @field TSField 
-      highlight! link @function.builtin TSFuncBuiltin 
-      highlight! link @function.macro TSFuncMacro 
-      highlight! link @function TSFunction 
+      highlight! link @text.warning TSWarning
+      highlight! link @text.danger TSDanger
+      highlight! link @constant.builtin TSConstBuiltin
+      highlight! link @field TSField
+      highlight! link @function.builtin TSFuncBuiltin
+      highlight! link @function.macro TSFuncMacro
+      highlight! link @function TSFunction
       highlight! link @namespace TSNamespace
       highlight! link @parameter TSParameter
       highlight! link @property TSProperty

--- a/after/plugin/srcery.vim
+++ b/after/plugin/srcery.vim
@@ -43,6 +43,7 @@ let s:italic = g:srcery#palette.italic
 let s:underline = g:srcery#palette.underline
 let s:undercurl = g:srcery#palette.undercurl
 let s:inverse = g:srcery#palette.inverse
+let s:strikethrough = g:srcery#palette.strikethrough
 
 " }}}
 " Sneak: {{{
@@ -283,6 +284,11 @@ if has('nvim')
       highlight! link @delimiter TSDelimiter
       highlight! link @text.uri TSURI
       highlight! link @variable TSVariable
+
+      call srcery#helper#Highlight('@markup.strong', s:none, s:none, s:bold)
+      call srcery#helper#Highlight('@markup.italic', s:none, s:none, s:italic)
+      call srcery#helper#Highlight('@markup.underline', s:none, s:none, s:underline)
+      call srcery#helper#Highlight('@markup.strikethrough', s:none, s:none, s:strikethrough)
 
     endif
   endif

--- a/autoload/srcery.vim
+++ b/autoload/srcery.vim
@@ -160,6 +160,10 @@ if !exists('g:srcery_underline')
   let g:srcery_underline=1
 endif
 
+if !exists('g:srcery_strikethrough')
+  let g:srcery_strikethrough=1
+endif
+
 if !exists('g:srcery_inverse')
   let g:srcery_inverse=1
 endif
@@ -265,6 +269,11 @@ endif
 let g:srcery#palette.inverse = 'inverse,'
 if g:srcery_inverse == 0
   let g:srcery#palette.inverse = ''
+endif
+
+let g:srcery#palette.strikethrough = 'strikethrough,'
+if g:srcery_strikethrough == 0
+  let g:srcery#palette.strikethrough = ''
 endif
 
 " }}}

--- a/doc/srcery.txt
+++ b/doc/srcery.txt
@@ -21,6 +21,7 @@ Options					|srcery-options|
 	g:srcery_italic			|srcery-option-italic|
 	g:srcery_underline		|srcery-option-underline|
 	g:srcery_undercurl		|srcery-option-undercurl|
+	g:srcery_strikethrough		|srcery-option-strikethrough|
 	g:srcery_inverse		|srcery-option-inverse|
 	g:srcery_inverse_matche		|srcery-option-inverse-matches|
 	g:srcery_inverse_match_paren	|srcery-option-inverse-match-paren|
@@ -171,6 +172,13 @@ g:srcery_underline
 g:srcery_undercurl
 
 	Enables undercurled text.
+
+	Default: 1
+
+						   *srcery-option-strikethrough*
+g:srcery_strikethrough
+
+	Enables strikethrough text.
 
 	Default: 1
 


### PR DESCRIPTION
Fix treesitter markup
====

- [x] Add new strikethrough option
  - Used only with tree sitter for now, but good to have defined
- [x] Fix missing treesitter markup highlights
  - Fixes issue with markup mentioned in issue #117 by defining markup highlights, including strikethrough
