### PR TITLE
fix: define NormalFloat

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -174,6 +174,7 @@ call s:HL('SrceryXgray6', s:xgray6)
 call s:HL('Normal', s:bright_white, g:srcery_bg)
 
 call s:HL('FloatBorder', s:white, g:srcery_bg)
+call s:HL('NormalFloat', s:none, s:xgray2)
 
 if v:version >= 700
   " Screen line that the cursor is


### PR DESCRIPTION
Neovim version `0.10` unlinked `NormalFloat` with `pmenu`, which caused the popup background color to default to undefined (black/magenta etc depending on what the default colorscheme is)

Should fix the issue reported by @milogert on discord, and return the previous colors

Ref: #119, #111, #116