### PR TITLE
Fix/nvim 0.10 - Define CurSearch

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -222,10 +222,12 @@ hi! link VisualNOS Visual
 
 if g:srcery_inverse == 1 && g:srcery_inverse_matches == 1
   call s:HL('Search', s:none, s:none, s:inverse)
-  call s:HL('IncSearch', s:none, s:none, s:inverse)
+  call s:HL('IncSearch', s:none, s:none, s:underline . s:inverse . s:bold)
+  call s:HL('CurSearch', s:none, s:none, s:underline . s:inverse . s:bold)
 else
-  call s:HL('Search', s:none, s:xgray5, s:bold)
+  call s:HL('Search', s:none, s:xgray5)
   call s:HL('IncSearch', s:none, s:xgray5, s:underline . s:bold)
+  call s:HL('CurSearch', s:none, s:xgray5, s:underline . s:bold)
 endif
 
 call s:HL('Underlined', s:blue, s:none, s:underline)


### PR DESCRIPTION
Fix/nvim 0.10 - Define CurSearch
=====

## Changes

Define CurSearch along the other search highlights, set it to use xgray/inverse, and be underline and bold. Tweak existing search groups to work with new CurSearch,

Seems some defaults changed or this hl group got added in nvim 0.10, `CurSearch` is the `hlsearch` word under the cursor. It was set to default colorscheme yellow, which messed with text selection, and don't work with how search is colorized in srcery.

Ref: #120

## Screenshot
![pr_cursearch](https://github.com/srcery-colors/srcery-vim/assets/4509009/8ee792cd-d620-4b52-a58b-d050110db0cb)
