### PR TITLE
fix: adjust highlights for common LazyVim plugins

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -1379,6 +1379,30 @@ if has('nvim')
   endif
 
   " }}}
+  " snacks.nvim {{{
+
+  highlight! link SnacksNormal Normal
+  highlight! link SnacksNormalNC Normal
+  highlight! link SnacksPicker Normal
+  highlight! link SnacksPickerDir Comment
+  highlight! link SnacksPickerGitStatusIgnored Comment
+  highlight! link SnacksPickerGitStatusUntracked Comment
+  highlight! link SnacksPickerPathHidden Comment
+  highlight! link SnacksPickerPathIgnored Comment
+  highlight! link SnacksPickerTotals Comment
+
+  " }}}
+  " trouble.nvim {{{
+
+  highlight! link TroubleNormal Normal
+  highlight! link TroubleNormalNC Normal
+
+  " }}}
+  " which-key.nvim {{{
+
+  highlight! link WhichKeyNormal Normal
+
+  " }}}
 endif
 
 " }}}


### PR DESCRIPTION
fixes #125 

Result:
![nvim_srcery_pr_01](https://github.com/user-attachments/assets/dbe076a2-8225-4fae-95a2-3508a3e80fc1)
![nvim_srcery_pr_02](https://github.com/user-attachments/assets/4f5a01ec-a44d-4776-922d-664c89e0f9bc)
